### PR TITLE
Add roles and labels to Luna nav

### DIFF
--- a/source/layout.html
+++ b/source/layout.html
@@ -27,7 +27,7 @@
     {% endif %}
     <header>
       <div class="wrapper">
-        <nav class="header-nav">
+        <nav class="header-nav" role="navigation" aria-label="Main">
           <ul>
             <li{% if page.full_url contains '/products' or page.full_url contains '/product/' or page.full_url contains '/category/' or page.full_url contains '/artist/' %} class="selected"{% endif %}><a href="/products">{{ pages.products.name }}</a></li>
             {% for page in pages.all limit:theme.nav_items %}
@@ -48,7 +48,7 @@
           </a>
         </div>
       </div>
-      <nav class="header-nav mobile-nav">
+      <nav class="header-nav mobile-nav" aria-label="Mobile Main" role="navigation">
         <ul>
           <li{% if page.full_url contains '/products' or page.full_url contains '/product/' or page.full_url contains '/category/' or page.full_url contains '/artist/' %} class="selected"{% endif %}><a href="/products">{{ pages.products.name }}</a></li>
           <li{% if page.full_url contains '/cart' %} class="selected"{% endif %}><a href="/cart">Cart</a></li>


### PR DESCRIPTION
Tested using the ChromeVox extension.

I added the aria-label to each version of the header  nav in order to distinguish
them from the footer nav. The screen reader will now include the aria-label
in its description of the nav. That choice was based on [this MDN
resource](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Navigation_Role)
The footer nav did not need an extra aria-label because it is nested
inside of the footer element, and the screen reader already includes the
word "footer"-- the aria-label would have also said "footer" and been
redundant.

For the screen reader, the role="navigation" attr had to be present in
order for the aria-label to be included in the spoken description.

[PT Story](https://www.pivotaltracker.com/story/show/169550274)