### PR TITLE
Add contentinfo role to footer

### DIFF
--- a/source/layout.html
+++ b/source/layout.html
@@ -138,9 +138,9 @@
         {% endif %}
       </div>
     {% endif %}
-    <footer>
+    <footer role="contentinfo">
       <div class="wrapper">
-        <nav class="footer-nav" id="footer">
+        <nav class="footer-nav" id="footer" role="navigation" aria-label="Footer">
           <ul class="footer-links">
             <li><a href="/">Home</a></li>
             <li><a href="/products">{{ pages.products.name }}</a></li>


### PR DESCRIPTION
This addresses a bug in Apple VoiceOver where the footer content isn't
announced. Assigning it a role of "contentinfo" allows VoiceOver to
recognize it as a footer.

Previously, I had left out an aria-label for the footer nav to avoid
screen reader repetition of the word "footer," but "contentinfo" seems
to work well with aria-label="Footer".

[PT Story](https://www.pivotaltracker.com/story/show/169649155)
[Resource](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer#Accessibility_concerns)