### PR TITLE
Remove alt description from images

### DIFF
--- a/source/products.html
+++ b/source/products.html
@@ -35,7 +35,7 @@
         <a class="product-list-item {{ theme.show_overlay }}" href="{{ product.url }}" title="View {{ product.name | escape }}">
           <div class="product-list-item-container">
             <figure class="product-list-image-container">
-              <img alt="Image of {{ product.name | escape }}" class="fade-in product-list-image {% if product.image.height > product.image.width %}image-tall{% elsif product.image.height < product.image.width %}image-wide{% else %}image-square{% endif %}" src="{{ product.image | product_image_url | constrain: 1000, 1000 }}">
+              <img alt="" class="fade-in product-list-image {% if product.image.height > product.image.width %}image-tall{% elsif product.image.height < product.image.width %}image-wide{% else %}image-square{% endif %}" src="{{ product.image | product_image_url | constrain: 1000, 1000 }}">
             </figure>
           </div>
           <div class="product-list-item-info">


### PR DESCRIPTION
The text within the link will be read by the screen reader instead. If
the alt tag was also present, the screen reader would read the same info
2x.

Fixes https://www.pivotaltracker.com/story/show/169827431