### PR TITLE
Add margin for announcement close button

### DIFF
--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -462,6 +462,7 @@ a.back-to-site
     background-color: $secondary-background-color
     height: 54px
     width: 44px
+    margin-top: -1px
 
     svg
       fill: $primary-text-color


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/169881422

_____
I noticed this issue when I pushed Luna up to staging.

**Before**
It's a little hard to see, but the button is hanging over the bottom of the banner by 1px.
<img width="155" alt="Screen Shot 2019-11-22 at 5 37 51 PM" src="https://user-images.githubusercontent.com/13512356/69465322-dfb4ce00-0d4e-11ea-9a8e-992dc90637c8.png">

**After**
<img width="140" alt="Screen Shot 2019-11-22 at 5 38 05 PM" src="https://user-images.githubusercontent.com/13512356/69465321-dfb4ce00-0d4e-11ea-881d-4ec6e30e9e03.png">


