### PR TITLE
Add hidden label to cart quantity inputs

### DIFF
--- a/source/cart.html
+++ b/source/cart.html
@@ -15,7 +15,8 @@
               {% endunless %}
             </a>
             <div class="cart-item-quantity-holder" data-item-id="{{ item.id }}">
-              {{ item | item_quantity_input, 'option-quantity', 'option-quantity' }}
+              <label for="item_{{item.id}}_qty">Quantity</label>
+              {{ item | item_quantity_input, nil, 'option-quantity' }}
             </div>
             <a class="cart-item-remove" title="Remove item" href="#">
               <svg aria-hidden="true" width="11" height="11" xmlns="http://www.w3.org/2000/svg">

--- a/source/stylesheets/cart.sass
+++ b/source/stylesheets/cart.sass
@@ -107,6 +107,16 @@
   padding: 0 $luna-base * 4
   width: 116px
 
+  label
+    border: 0
+    clip: rect(0 0 0 0)
+    height: 1px
+    margin: -1px
+    overflow: hidden
+    padding: 0
+    position: absolute
+    width: 1px
+
   input
     box-shadow: none
     text-align: center


### PR DESCRIPTION
I set the `id` argument in the input tag to `nil` so that each input
will have a unique id. Currently, all inputs have the same id.

CSS approach from:
https://www.w3.org/WAI/tutorials/forms/labels/#note-on-hiding-elements

Fixes https://www.pivotaltracker.com/story/show/169925599