### PR TITLE
Convert remove item link to button

### DIFF
--- a/source/cart.html
+++ b/source/cart.html
@@ -20,11 +20,11 @@
               <label for="item_{{item.id}}_qty">Quantity</label>
               {{ item | item_quantity_input, nil, 'option-quantity' }}
             </div>
-            <a class="cart-item-remove" title="Remove item" href="#">
+            <button title="Remove item: {{ item.product.name }}" class="cart-item-remove" aria-label="Remove item: {{ item.product.name }}">
               <svg aria-hidden="true" width="11" height="11" xmlns="http://www.w3.org/2000/svg">
                 <path d="M9.5 1.45l-8 8.1m0-8.1l8 8.1" stroke="#666" stroke-width="2" fill="none" fill-rule="evenodd" stroke-linecap="round"/>
               </svg>
-            </a>
+            </button>
           </li>
         {% endfor %}
       </ul>

--- a/source/stylesheets/cart.sass
+++ b/source/stylesheets/cart.sass
@@ -48,7 +48,7 @@
   @media screen and (max-width: $break-small)
     padding: $luna-base * 2 20px
 
-.cart-item-remove
+button.cart-item-remove
   +all-transitions
   +flexbox
   +align-items(center)
@@ -57,14 +57,19 @@
   border-radius: 50%
   padding: $luna-base
   cursor: pointer
+  background-color: transparent
+  transition: 0.2s linear
+  height: inherit
+  width: inherit
+
+  &:hover, &:active, &:focus
+    background-color: transparent
+    border: 2px solid $primary-text-color
 
   .cart-remove-icon
     +all-transitions
     display: block
     fill: $secondary-text-color
-
-  &:hover, &:active, &:focus
-    border: 2px solid $primary-text-color
 
     .cart-remove-icon
       fill: $primary-text-color


### PR DESCRIPTION
Converting from a link to a button allows users to interact with buttons
with either the space key or enter key-- ie we enable default button
behaviors. This element is a button because it triggers an action and
does not navigate to another page or view.

Fixes https://www.pivotaltracker.com/story/show/169827557