### PR TITLE
Update image constraint for cart

### DIFF
--- a/source/cart.html
+++ b/source/cart.html
@@ -6,7 +6,9 @@
       <ul class="cart-items">
         {% for item in cart.items %}
           <li class="cart-item" data-item-id="{{ item.id }}">
-            <a class="cart-item-image" href="{{ item.product.url }}"><img src="{{ item.product.image | product_image_url | constrain: 576, 576 }}" alt="View {{ item.product.name | escape }}" title="View {{ item.product.name | escape }}" /></a>
+            <a class="cart-item-image" href="{{ item.product.url }}">
+              <img src="{{ item.product.image | product_image_url | constrain: 200, 200 }}" alt="View {{ item.product.name | escape }}" title="View {{ item.product.name | escape }}" />
+            </a>
             <a class="cart-item-details" href="{{ item.product.url }}" title="View {{ item.product.name | escape }}">
               <div class="cart-item-details-name">{{ item.product.name }}</div>
               <div class="cart-item-details-price">{{ item.unit_price | money: theme.money_format }}</div>

--- a/source/stylesheets/cart.sass
+++ b/source/stylesheets/cart.sass
@@ -77,8 +77,6 @@
   margin-top: 10px
 
 .cart-item-image
-  background-position: 50% 50%
-  background-size: cover
   display: block
   height: 90px
   margin-right: 20px
@@ -87,6 +85,7 @@
 
   img
     object-fit: cover
+    height: inherit
     width: 100%
 
   @media screen and (max-width: $break-small)


### PR DESCRIPTION
Reduces the size constraint to prevent the image from overflowing
the height of the row. `200,200` matches the size of Lunch
Break cart images.

Fixes https://www.pivotaltracker.com/story/show/170001634