### PR TITLE
Use class to hide AT-only elements

### DIFF
--- a/source/cart.html
+++ b/source/cart.html
@@ -17,7 +17,7 @@
               {% endunless %}
             </a>
             <div class="cart-item-quantity-holder" data-item-id="{{ item.id }}">
-              <label for="item_{{item.id}}_qty">Quantity</label>
+              <label class="visually-hidden" for="item_{{item.id}}_qty">Quantity</label>
               {{ item | item_quantity_input, nil, 'option-quantity' }}
             </div>
             <button title="Remove item: {{ item.product.name }}" class="cart-item-remove" aria-label="Remove item: {{ item.product.name }}">

--- a/source/home.html
+++ b/source/home.html
@@ -8,6 +8,7 @@
   </div>
 {% endif %}
 
+<h1 class="visually-hidden">Featured Products</h1>
 {% if theme.featured_items > 0 %}
   {% get products from products.all limit:theme.featured_items order:theme.featured_order %}
     {% if products != blank %}

--- a/source/products.html
+++ b/source/products.html
@@ -19,6 +19,7 @@
   </nav>
   {% endif %}
 </div>
+<h1 class="visually-hidden">{{ page.name }}</h1>
 {% paginate products from products.current by theme.products_per_page %}
   {% if products != blank %}
     <div class="product-list">

--- a/source/stylesheets/cart.sass
+++ b/source/stylesheets/cart.sass
@@ -115,16 +115,6 @@ button.cart-item-remove
   padding: 0 $luna-base * 4
   width: 116px
 
-  label
-    border: 0
-    clip: rect(0 0 0 0)
-    height: 1px
-    margin: -1px
-    overflow: hidden
-    padding: 0
-    position: absolute
-    width: 1px
-
   input
     box-shadow: none
     text-align: center

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -481,6 +481,16 @@ a.back-to-site
   a
     text-decoration: underline
 
+.visually-hidden
+  border: 0
+  clip: rect(0 0 0 0)
+  height: 1px
+  margin: -1px
+  overflow: hidden
+  padding: 0
+  position: absolute
+  width: 1px
+
 @keyframes reset
   from
     opacity: 0


### PR DESCRIPTION
The h1 is available for assistive technologies, but it isn't needed for
design.

Fixes https://www.pivotaltracker.com/story/show/170060356


----
Note: there are other TODOs in that PT story-- I will make separate PRs for them because there are some additional design considerations to follow up on.