### PR TITLE
Remove bottom category nav

### DIFF
--- a/source/products.html
+++ b/source/products.html
@@ -55,28 +55,6 @@
         {{ paginate | default_pagination }}
       </nav>
     {% endif %}
-
-    <div class="artist-category-nav artist-category-nav-footer">
-      <nav class="category-nav" role="navigation" aria-label="Category sub-nav">
-        <div class="nav-title">Products</div>
-        <ul>
-          <li class="{% if page.full_url contains '/products' %}selected{% endif %}"><a href="/products">All</a></li>
-          {% for category in categories.active %}
-          <li class="{% if page.full_url contains category.url %}selected{% endif %}">{{ category | link_to }}</li>
-          {% endfor %}
-        </ul>
-      </nav>
-      {% if artists.active != blank %}
-      <nav class="artist-nav">
-        <div class="nav-title">Artists</div>
-        <ul>
-          {% for artist in artists.active %}
-          <li class="{% if page.full_url contains artist.url %}selected{% endif %}">{{ artist | link_to }}</li>
-          {% endfor %}
-        </ul>
-      </nav>
-      {% endif %}
-    </div>
   {% else %}
     <div class="empty-products centered-message">No products found.</div>
   {% endif %}

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -335,7 +335,7 @@ button, a.button
     &.footer-links
       @media screen and (max-width: $break-small)
         +flex-direction(column)
-        padding: 0 $luna-base * 2
+        padding: 0 20px
         width: 100%
 
         a

--- a/source/stylesheets/products.sass
+++ b/source/stylesheets/products.sass
@@ -243,12 +243,13 @@
   +justify-content(center)
   font-family: $secondary-font
   font-size: 15px
-  margin: $luna-base * 5 auto 0
+  margin: 60px auto 0
   padding: $luna-base * 3
   width: 100%
 
   @media screen and (max-width: $break-small)
     font-size: 16px
+    margin-bottom: $luna-base * 3
     margin-top: $luna-base * 3
 
   a, span
@@ -263,5 +264,10 @@
     &.current
       text-decoration: underline
 
-#products_page .footer-nav
-  border-top: 0px
+#products_page .footer-nav, #home_page .footer-nav
+  @media screen and (max-width: $break-small)
+    border-top: 0px
+
+#products_page .main .wrapper, #home_page .main .wrapper
+  @media screen and (max-width: $break-small)
+    border-bottom: 1px solid $border-color


### PR DESCRIPTION
Because it was a duplicate of the category nav at the top of the product
grid, it violated the rule that landmarks must be unique. It could be
challenging or frustrating for a user relying on accessibility tools to
figure out if there was a difference between the 2 navs. The project
team decided it was okay to remove the second nav.

Fixes https://www.pivotaltracker.com/story/show/170060356
Related to
https://www.pivotaltracker.com/n/projects/1902125/stories/169828506

--------
## Screenies:

### Mobile home (set border width to match the footer lines as well)
<img width="534" alt="Screen Shot 2019-12-06 at 2 15 25 PM" src="https://user-images.githubusercontent.com/13512356/70349651-261c2980-1833-11ea-825f-ffa46b38252e.png">

### Mobile products with pagination
<img width="507" alt="Screen Shot 2019-12-06 at 2 15 18 PM" src="https://user-images.githubusercontent.com/13512356/70349660-2ae0dd80-1833-11ea-8b02-6da6a82f6467.png">

### Mobile category, no pagination
<img width="531" alt="Screen Shot 2019-12-06 at 2 20 09 PM" src="https://user-images.githubusercontent.com/13512356/70349835-8ad78400-1833-11ea-9139-5df0a4e3a1fb.png">

### Desktop pagination (evened out spacing above/below the pag.)
<img width="1259" alt="Screen Shot 2019-12-06 at 2 11 54 PM" src="https://user-images.githubusercontent.com/13512356/70349667-30d6be80-1833-11ea-8b01-902a94d2d963.png">

### Desktop homepage (no change)
<img width="1187" alt="Screen Shot 2019-12-06 at 2 18 31 PM" src="https://user-images.githubusercontent.com/13512356/70349718-4c41c980-1833-11ea-8dc3-6d6cc8136afd.png">
