### PR TITLE
fix: decrease reCaptcha note font size

### DIFF
--- a/source/stylesheets/contact.sass
+++ b/source/stylesheets/contact.sass
@@ -27,7 +27,7 @@
 
 .recaptcha-note
   font-family: $secondary-font
-  font-size: $luna-font-base-px - 2
+  font-size: $luna-font-base-px - 4
   font-style: italic
   line-height: 1.3em
   opacity: .8


### PR DESCRIPTION
Luna base is 16px and 14px was too large for this. Decreasing by another 2px to 12px.