### PR TITLE
fix: hide category nav on products search results

### DIFF
--- a/source/products.html
+++ b/source/products.html
@@ -18,17 +18,16 @@
       {% endunless %}
     </nav>
     {% if artists.active != blank %}
-    <nav class="products-nav artist-nav" aria-label="Artist navigation">
       {% unless page.full_url contains 'search=' %}
-        <div class="nav-title">Artists</div>
+        <nav class="products-nav artist-nav" aria-label="Artist navigation">
+          <div class="nav-title">Artists</div>
           <ul>
             {% for artist in artists.active %}
               <li class="{% if page.full_url contains artist.url %}selected{% endif %}">{{ artist | link_to }}</li>
             {% endfor %}
           </ul>
-        </div>
+        </nav>
       {% endunless %}  
-    </nav>
     {% endif %}
   </div>
 {% endif %}

--- a/source/products.html
+++ b/source/products.html
@@ -1,22 +1,33 @@
 {% if categories.active != blank or artists.active != blank %}
   <div class="artist-category-nav artist-category-nav-header">
     <nav aria-label="Category navigation" class="category-nav products-nav">
-      <div class="nav-title">Products</div>
+      <div class="nav-title">
+        {% if page.full_url contains "search=" %}
+          Search Results
+        {% else %}
+          {{ page.name }}
+        {% endif %}
+      </div>
+      {% unless page.full_url contains 'search=' %}
       <ul>
         <li class="{% if page.full_url contains '/products' %}selected{% endif %}"><a href="/products">All</a></li>
         {% for category in categories.active %}
           <li class="{% if page.full_url contains category.url %}selected{% endif %}">{{ category | link_to }}</li>
         {% endfor %}
       </ul>
+      {% endunless %}
     </nav>
     {% if artists.active != blank %}
     <nav class="products-nav artist-nav" aria-label="Artist navigation">
-      <div class="nav-title">Artists</div>
-      <ul>
-        {% for artist in artists.active %}
-          <li class="{% if page.full_url contains artist.url %}selected{% endif %}">{{ artist | link_to }}</li>
-        {% endfor %}
-      </ul>
+      {% unless page.full_url contains 'search=' %}
+        <div class="nav-title">Artists</div>
+          <ul>
+            {% for artist in artists.active %}
+              <li class="{% if page.full_url contains artist.url %}selected{% endif %}">{{ artist | link_to }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endunless %}  
     </nav>
     {% endif %}
   </div>

--- a/source/products.html
+++ b/source/products.html
@@ -1,13 +1,13 @@
 {% if categories.active != blank or artists.active != blank %}
   <div class="artist-category-nav artist-category-nav-header">
     <nav aria-label="Category navigation" class="category-nav products-nav">
-      <div class="nav-title">
+      <h1 class="nav-title">
         {% if page.full_url contains "search=" %}
           Search Results
         {% else %}
           {{ page.name }}
         {% endif %}
-      </div>
+      </h1>
       {% unless page.full_url contains 'search=' %}
       <ul>
         <li class="{% if page.full_url contains '/products' %}selected{% endif %}"><a href="/products">All</a></li>
@@ -31,7 +31,6 @@
     {% endif %}
   </div>
 {% endif %}
-<h1 class="page-title visually-hidden">{{ page.name }}</h1>
 {% paginate products from products.current by theme.products_per_page %}
   {% if products != blank %}
     <div class="product-list-container">

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Luna",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "images": [
     {
       "variable": "header",

--- a/source/stylesheets/products.sass
+++ b/source/stylesheets/products.sass
@@ -16,6 +16,7 @@
   .nav-title
     font-size: $luna-font-base-px + 2
     font-weight: bold
+    text-transform: none
 
   nav
     text-align: center


### PR DESCRIPTION
The category nav does not have a use on search results and is confusing

before
![image](https://github.com/user-attachments/assets/b079becd-d44c-4b3f-9246-e9e6167f1c6c)


after
![image](https://github.com/user-attachments/assets/1a0ae18a-10d6-470b-8d3d-3bb7832309ac)