### PR TITLE
fix: `Products` page title correctly reflect search results or custom page name

### DIFF
--- a/source/products.html
+++ b/source/products.html
@@ -1,7 +1,7 @@
 {% if categories.active != blank or artists.active != blank %}
   <div class="artist-category-nav artist-category-nav-header">
     <nav aria-label="Category navigation" class="category-nav products-nav">
-      <div class="nav-title">Products</div>
+      <div class="nav-title">{% if page.full_url contains 'search=' %}Product Search{% else %}{% if page.name == 'Products' %}All Products{% else %}{{ page.name }}{% endif %}{% endif %}</div>
       <ul>
         <li class="{% if page.full_url contains '/products' %}selected{% endif %}"><a href="/products">All</a></li>
         {% for category in categories.active %}

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Luna",
-  "version": "2.7.0",
+  "version": "2.7.2",
   "images": [
     {
       "variable": "header",


### PR DESCRIPTION
This was always "Products" which is wrong if you've customized the Products page name in Shop Designer. This change mimics the other themes where it looks for the `search=` query string param to state "Product Search", otherwise the title will be the custom page name.