### PR TITLE
feat: add home featured products title and all products button

### DIFF
--- a/source/home.html
+++ b/source/home.html
@@ -17,9 +17,9 @@
   </div>
 {% endif %}
 
-<h1 class="visually-hidden">Featured Products</h1>
+<h1 class="page-title">{{ theme.featured_header }}</h1>
 {% if theme.featured_items > 0 %}
-  {% get products from products.all limit:theme.featured_items order:theme.featured_order %}
+  {% paginate products from products.all by theme.featured_items order:theme.featured_order %}
     {% if products != blank %}
       <div class="product-list-container">
         <div class="product-list {% if products.size < 4 %}product-list--center{% endif %}" data-max-products-desktop="{{ theme.max_products_per_row }}" data-max-products-mobile="{{ theme.max_products_per_row_mobile }}">
@@ -72,8 +72,11 @@
           {% endfor %}
         </div>
       </div>
+      {% if paginate.pages > 1 %}
+        {% if theme.all_products_button_text != blank %}<a class="button all-products-button" href="/products">{{ theme.all_products_button_text }}</a>{% endif %}
+      {% endif %}
     {% else %}
       <div class="empty-products centered-message">No products found.</div>
     {% endif %}
-  {% endget %}
+  {% endpaginate %}
 {% endif %}

--- a/source/settings.json
+++ b/source/settings.json
@@ -329,6 +329,13 @@
       "description": "The number of custom page links to display in the main navigation."
     },
     {
+      "variable": "featured_header",
+      "label": "Featured products header",
+      "type": "text",
+      "description": "Displays above featured products on the Home page",
+      "default": "Featured Products"
+    },
+    {
       "variable": "featured_items",
       "label": "Featured products",
       "type": "select",
@@ -378,6 +385,13 @@
       ],
       "default": "crop-to-square",
       "description": "Sets the display of images in the product grid"
+    },
+    {
+      "variable": "all_products_button_text",
+      "label": "All products button text",
+      "type": "text",
+      "description": "Displays underneath featured products and links to your Products Page",
+      "default": "All Products"
     },
     {
       "variable": "show_overlay",

--- a/source/stylesheets/home.sass
+++ b/source/stylesheets/home.sass
@@ -50,3 +50,18 @@
       &.is-active
         background: var(--pagination-active-page)
         transform: scale(1.1)
+
+a.all-products-button
+  max-width: 300px
+  margin: 48px auto 0
+  background: none
+  border: 2px solid var(--primary-text-color)
+  color: var(--primary-text-color)
+  display: flex
+  align-items: center
+  justify-content: center
+
+  &:hover, &:focus
+    background: none
+    border: 2px solid var(--links-rollover-color)
+    color: var(--button-text-color)

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -238,6 +238,10 @@ header
 
   @media screen and (max-width: $break-small)
     padding-bottom: 0
+  
+  h1.page-title
+    font-size: 20px
+    text-align: center
 
 _:-ms-fullscreen, :root .main
   +flex(1 0 auto)


### PR DESCRIPTION
Add support for featured products title on homepage, including "all products" button if there are more products than what is shown as featured.

Added appropriate settings to control each.

### Heading
![image](https://github.com/user-attachments/assets/cbe54ec5-57bd-44e6-a19f-bf63b5f19a4b)

### Button at bottom of page
![image](https://github.com/user-attachments/assets/06e1dc3c-73fe-4400-bf4a-a88f5ca3def3)
