### PR TITLE
chore: add attributes for data hook on header and footer, and page type in layout

### DIFF
--- a/source/layout.html
+++ b/source/layout.html
@@ -9,7 +9,7 @@
     <style>.preloader * { opacity: 0; }.transition-preloader * { transition: none !important }</style>
   </head>
 
-  <body id="{{ page.permalink }}_page" class="{{ page.category }} preloader transition-preloader">
+  <body id="{{ page.permalink }}_page" class="{{ page.category }} preloader transition-preloader" data-bc-page-type="{% if page.category == 'custom' %}custom{% else %}{{ page.permalink }}{% endif %}">
     <div id="fb-root"></div>
     <script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v19.0" nonce="MwnpJNps"></script>
     <a class="skip-link" href="#main">Skip to main content</a>
@@ -23,7 +23,7 @@
         </button>
       </div>
     {% endif %}
-    <header>
+    <header data-bc-hook="header">
       <div class="wrapper">
         <nav class="header-nav" role="navigation" aria-label="Main">
           <ul>
@@ -165,7 +165,7 @@
 
 
 
-    <footer>
+    <footer data-bc-hook="footer">
       <div class="wrapper">
         <nav class="footer-nav" id="footer" role="navigation" aria-label="Footer">
           <ul class="footer-links">

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Luna",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "images": [
     {
       "variable": "header",


### PR DESCRIPTION
Allows for 3rd party apps to target key regions for adding content. In particular, key for omnisend and email partners to be able to insert content above the footer.

1. Adds `data-bc-hook` attribute to header and footer
2. Adds `data-bc-page-type` attribute to the body tag

Note: A much larger change was previously proposed but I've scaled it back to only the above 2 changes foregoing the larger change which is much more complex.
