### PR TITLE
Remove social media share buttons

### DIFF
--- a/source/product.html
+++ b/source/product.html
@@ -90,36 +90,6 @@
         </div>
       {% endif %}
     {% endif %}
-
-    {% if theme.show_facebook or theme.show_twitter or theme.show_pinterest %}
-      <ul class="social-buttons">
-        {% if theme.show_facebook %}
-          <li class="social-facebook">
-            <div class="social-title">Share it</div>
-            <div class="social-action">
-              <div class="fb-share-button" data-href="{{ page.full_url }}" data-layout="button" data-size="small" data-mobile-iframe="true"><a target="_blank" href="https://www.facebook.com/sharer/sharer.php?u={{ page.full_url }}src=sdkpreparse" class="fb-xfbml-parse-ignore">Share</a></div>
-            </div>
-          </li>
-        {% endif %}
-        {% if theme.show_twitter %}
-          <li class="social-twitter">
-            <div class="social-title">Tweet It</div>
-            <div class="social-action">
-              <a href="https://twitter.com/share" class="twitter-share-button" data-url="{{ page.full_url }}" data-text="Check out {{ product.name }} from {{ store.name }}!">Tweet</a> <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
-            </div>
-          </li>
-        {% endif %}
-        {% if theme.show_pinterest %}
-          <li class="social-pinterest">
-            <div class="social-title">Pin It</div>
-            <div class="social-action">
-              <a href="http://pinterest.com/pin/create/button/?url={{ page.full_url }}&media={{ product.image.url }}&description={% if product.description != blank %}{{ product.description | escape | truncate: 490 }}{% endif %}" class="pin-it-button" count-layout="horizontal"><img border="0" src="//assets.pinterest.com/images/PinExt.png" title="Pin It"></a>
-              <script type="text/javascript" src="//assets.pinterest.com/js/pinit.js"></script>
-            </div>
-          </li>
-        {% endif %}
-      </ul>
-    {% endif %}
   </div>
   <div class="product-images desktop-{{ theme.desktop_product_page_images }} mobile-{{ theme.mobile_product_page_images }}" data-total-images="{{ product.images.size }}">
     {% if product.images.size > 1 %}

--- a/source/settings.json
+++ b/source/settings.json
@@ -496,27 +496,6 @@
       "requires": "inventory"
     },
     {
-      "variable": "show_facebook",
-      "label": "Show Facebook's Share button",
-      "type": "boolean",
-      "default": false,
-      "description": "Adds a Share button to the Product page"
-    },
-    {
-      "variable": "show_twitter",
-      "label": "Show Twitter's Tweet button",
-      "type": "boolean",
-      "default": false,
-      "description": "Adds a Tweet button to the Product page"
-    },
-    {
-      "variable": "show_pinterest",
-      "label": "Show Pinterest's Pin It button",
-      "type": "boolean",
-      "default": false,
-      "description": "Adds a Pin It button to the Product page"
-    },
-    {
       "variable": "instagram_url",
       "label": "Instagram URL",
       "type": "text",

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -122,55 +122,6 @@
     border-radius: var(--border-radius)
     width: 100%
 
-  .social-buttons
-    border: 1px solid var(--border-color)
-    font-family: var(--secondary-font)
-    font-size: 14px
-    list-style: none
-    margin: $luna-base * 4 0 0
-    padding: 0
-    text-transform: uppercase
-    letter-spacing: .5px
-
-    li
-      +flexbox
-      +justify-content(center)
-      +align-items(center)
-      border-bottom: 1px solid var(--border-color)
-      height: 54px
-      overflow: hidden
-      position: relative
-      text-align: center
-
-      .social-title
-        display: block
-        position: absolute
-        width: 100%
-
-      .social-action
-        opacity: 0
-        position: relative
-        visibility: hidden
-
-      &:hover
-        .social-title
-          display: none
-
-        .social-action
-          opacity: 1
-          visibility: visible
-
-      @media screen and (max-width: $break-small)
-        .social-title
-          display: none
-
-        .social-action
-          opacity: 1
-          visibility: visible
-
-      &:last-child
-        border-bottom: 0px
-
 .similar-product-list
   +justify-content(flex-start)
 


### PR DESCRIPTION
Due to issues with the Facebook share button in some browsers, along with the low engagement on these buttons year over year, the share option is being removed from the theme altogether. Instead, visitors can copy/paste URLs, use browser plugins, or use the native share buttons on mobile browsers.