### PR TITLE
feat: add color settings for primary vs secondary product status

### DIFF
--- a/source/home.html
+++ b/source/home.html
@@ -40,6 +40,7 @@
               {% when 'coming-soon' %}
                 {% assign product_status = 'Coming soon' %}
             {% endcase %}
+            {% capture status_class %}{% if product.status == 'active' and product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
             <div class="product-list-thumb {{ product.css_class }}">
               <a class="product-list-link product-list-link--{{ theme.show_overlay }}" href="{{ product.url }}" title="View {{ product.name | escape }}">
                 <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
@@ -71,7 +72,7 @@
                       {% endif %}
                     {% endunless %}
                   </div>
-                  {% if product_status != blank %}<div class="product-list-thumb-status">{{ product_status }}</div>{% endif %}
+                  {% if product_status != blank %}<div class="product-list-thumb-status {{ status_class }}">{{ product_status }}</div>{% endif %}
                 </div>
               </a>
             </div>

--- a/source/product.html
+++ b/source/product.html
@@ -7,9 +7,10 @@
 	{% when 'coming-soon' %}
 		{% assign product_status = 'Coming soon' %}
 {% endcase %}
+{% capture status_class %}{% if product.status == 'active' and product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
 <div class="product-page {{ theme.product_page_layout }}">
   <div class="product-page-headings">
-    {% if product_status != blank %}<div class="product-status">{{ product_status }}</div>{% endif %}
+    {% if product_status != blank %}<div class="product-status {{ status_class }}">{{ product_status }}</div>{% endif %}
     <h1 class="product-title has-dash">{{ product.name }}</h1>
     <div class="product-price">
       {% unless product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}

--- a/source/products.html
+++ b/source/products.html
@@ -48,6 +48,7 @@
             {% when 'coming-soon' %}
               {% assign product_status = 'Coming soon' %}
           {% endcase %}
+          {% capture status_class %}{% if product.status == 'active' and product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
           <div class="product-list-thumb {{ product.css_class }}">
             <a class="product-list-link product-list-link--{{ theme.show_overlay }}" href="{{ product.url }}" title="View {{ product.name | escape }}">
               <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
@@ -79,7 +80,7 @@
                     {% endif %}
                   {% endunless %}
                 </div>
-                {% if product_status != blank %}<div class="product-list-thumb-status">{{ product_status }}</div>{% endif %}
+                {% if product_status != blank %}<div class="product-list-thumb-status {{status_class}}">{{ product_status }}</div>{% endif %}
               </div>
             </a>
           </div>

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Luna",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "images": [
     {
       "variable": "header",
@@ -39,7 +39,7 @@
             },
             "colors": {
               "background_color": "#FFFFFF",
-              "secondary_background_color": "#F3F3F3",
+              "secondary_background_color": "#FFFFFF",
               "primary_text_color": "#111111",
               "secondary_text_color": "#555555",
               "link_rollover_color": "#255B8A",
@@ -48,7 +48,9 @@
               "border_color": "#111111",
               "button_text_color": "#FFFFFF",
               "button_background_color": "#000000",
-              "button_rollover_color": "#255B8A"
+              "button_rollover_color": "#255B8A",
+              "product_status_text_color_primary": "#E60000",
+              "product_status_text_color_secondary": "#787878"
             }
           },
           {
@@ -59,7 +61,7 @@
             },
             "colors": {
               "background_color": "#141415",
-              "secondary_background_color": "#333333",
+              "secondary_background_color": "#141415",
               "primary_text_color": "#F8F8F8",
               "secondary_text_color": "#F8F8F8",
               "link_rollover_color": "#AEAEAE",
@@ -68,7 +70,9 @@
               "border_color": "#494949",
               "button_text_color": "#141415",
               "button_background_color": "#F8F8F8",
-              "button_rollover_color": "#AEAEAE"
+              "button_rollover_color": "#AEAEAE",
+              "product_status_text_color_primary": "#4E6EE8",
+              "product_status_text_color_secondary": "#CCCCCC"
             }
           },
           {
@@ -79,7 +83,7 @@
             },
             "colors": {
               "background_color": "#F8F8FA",
-              "secondary_background_color": "#FFFFFF",
+              "secondary_background_color": "#F8F8FA",
               "primary_text_color": "#2A2A2C",
               "secondary_text_color": "#2A2A2C",
               "link_rollover_color": "#203BE1",
@@ -88,7 +92,9 @@
               "border_color": "#E3E4EA",
               "button_text_color": "#FFFFFF",
               "button_background_color": "#203BE1",
-              "button_rollover_color": "#2A2A2C"
+              "button_rollover_color": "#2A2A2C",
+              "product_status_text_color_primary": "#E60000",
+              "product_status_text_color_secondary": "#888888"
             }
           }
         ]
@@ -103,7 +109,7 @@
               "secondary_font": "Cabin"
             },
             "colors": {
-              "background_color": "#F5F4EE",
+              "background_color": "#F2EEE7",
               "secondary_background_color": "#F2EEE7",
               "primary_text_color": "#262522",
               "secondary_text_color": "#262522",
@@ -113,7 +119,9 @@
               "border_color": "#C3C0B0",
               "button_text_color": "#F5F4EE",
               "button_background_color": "#262522",
-              "button_rollover_color": "#7C3C17"
+              "button_rollover_color": "#7C3C17",
+              "product_status_text_color_primary": "#A64300",
+              "product_status_text_color_secondary": "#7F7F7F"
             }
           },
           {
@@ -123,7 +131,7 @@
               "secondary_font": "Inter"
             },
             "colors": {
-              "background_color": "#141415",
+              "background_color": "#332F2F",
               "secondary_background_color": "#332F2F",
               "primary_text_color": "#FFF5E5",
               "secondary_text_color": "#FFF5E5",
@@ -133,7 +141,9 @@
               "border_color": "#605553",
               "button_text_color": "#222121",
               "button_background_color": "#CAB696",
-              "button_rollover_color": "#FFF5E5"
+              "button_rollover_color": "#FFF5E5",
+              "product_status_text_color_primary": "#FF8C00",
+              "product_status_text_color_secondary": "#888888"
             }
           },
           {
@@ -143,7 +153,7 @@
               "secondary_font": "Source Sans Pro"
             },
             "colors": {
-              "background_color": "#F1F1F1",
+              "background_color": "#EBE7E7",
               "secondary_background_color": "#EBE7E7",
               "primary_text_color": "#0F1B27",
               "secondary_text_color": "#0F1B27",
@@ -153,7 +163,9 @@
               "border_color": "#DBD1D1",
               "button_text_color": "#FFFFFF",
               "button_background_color": "#8A5A5A",
-              "button_rollover_color": "#0F1B27"
+              "button_rollover_color": "#0F1B27",
+              "product_status_text_color_primary": "#D08770",
+              "product_status_text_color_secondary": "#7F7F7F"
             }
           }
         ]
@@ -168,7 +180,7 @@
               "secondary_font": "Syne"
             },
             "colors": {
-              "background_color": "#FFFFFF",
+              "background_color": "#F2F2F3",
               "secondary_background_color": "#F2F2F3",
               "primary_text_color": "#0000FF",
               "secondary_text_color": "#0000FF",
@@ -178,7 +190,9 @@
               "border_color": "#E0E1E7",
               "button_text_color": "#0000FF",
               "button_background_color": "#FFE500",
-              "button_rollover_color": "#EBD300"
+              "button_rollover_color": "#EBD300",
+              "product_status_text_color_primary": "#FFA500",
+              "product_status_text_color_secondary": "#7F7F7F"
             }
           },
           {
@@ -188,7 +202,7 @@
               "secondary_font": "Quicksand"
             },
             "colors": {
-              "background_color": "#FFFBFD",
+              "background_color": "#FFECF7",
               "secondary_background_color": "#FFECF7",
               "primary_text_color": "#33246D",
               "secondary_text_color": "#33246D",
@@ -198,7 +212,9 @@
               "border_color": "#FFECF7",
               "button_text_color": "#FFFFFF",
               "button_background_color": "#FF169E",
-              "button_rollover_color": "#FF61BD"
+              "button_rollover_color": "#FF61BD",
+              "product_status_text_color_primary": "#FF169E",
+              "product_status_text_color_secondary": "#7F7F7F"
             }
           },
           {
@@ -208,7 +224,7 @@
               "secondary_font": "Prompt"
             },
             "colors": {
-              "background_color": "#5E2498",
+              "background_color": "#51168B",
               "secondary_background_color": "#51168B",
               "primary_text_color": "#FFFFFF",
               "secondary_text_color": "#C390F6",
@@ -218,7 +234,9 @@
               "border_color": "#C390F6",
               "button_text_color": "#FFFFFF",
               "button_background_color": "#D01A67",
-              "button_rollover_color": "#B0094F"
+              "button_rollover_color": "#B0094F",
+              "product_status_text_color_primary": "#FF1493",
+              "product_status_text_color_secondary": "#C390F6"
             }
           }
         ]
@@ -246,7 +264,7 @@
     {
       "variable": "secondary_background_color",
       "label": "Secondary background",
-      "default": "#F3F3F3"
+      "default": "#FFFFFF"
     },
     {
       "variable": "primary_text_color",
@@ -292,6 +310,16 @@
       "variable": "button_rollover_color",
       "label": "Button hover background",
       "default": "#255B8A"
+    },
+    {
+      "variable": "product_status_text_color_primary",
+      "label": "Product status text (primary)",
+      "default": "#E60000"
+    },
+    {
+      "variable": "product_status_text_color_secondary",
+      "label": "Product status text (secondary)",
+      "default": "#787878"
     }
   ],
   "options": [

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -24,6 +24,9 @@
   --primary-font: #{"{{ theme.primary_font | font_family }}"}
   --secondary-font: #{"{{ theme.secondary_font | font_family }}"}
 
+  --product-status-text-color-primary: #{"{{ theme.product_status_text_color_primary }}"}
+  --product-status-text-color-secondary: #{"{{ theme.product_status_text_color_secondary }}"}
+
 html
   height: 100%
   min-height: 100%

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -47,12 +47,17 @@
     font-weight: normal
 
   .product-status
-    color: var(--secondary-text-color)
     font-family: var(--secondary-font)
     font-size: $luna-font-base-px
     font-style: italic
     margin-bottom: $luna-base * 1.75
     text-align: center
+
+    &.status-primary
+      color: var(--product-status-text-color-primary)
+        
+    &.status-secondary
+      color: var(--product-status-text-color-secondary)
 
   .product-details
     grid-area: var(--details-grid-area)

--- a/source/stylesheets/products.sass
+++ b/source/stylesheets/products.sass
@@ -107,9 +107,6 @@ a.product-list-link
         transition: opacity .2s ease, visibility .2s ease
         color: var(--button-text-color)
 
-      .product-list-thumb-status
-        color: var(--button-text-color)
-
       &:hover, &:focus
         .product-list-thumb-info
           opacity: 1
@@ -146,7 +143,6 @@ a.product-list-link
     object-fit: contain
 
 .product-list-thumb-status
-  color: var(--secondary-text-color)
   font-family: var(--secondary-font)
   font-size: 1em
   font-style: italic
@@ -154,6 +150,12 @@ a.product-list-link
 
   @media screen and (max-width: $break-small)
     font-size: .975em
+  
+  &.status-primary
+    color: var(--product-status-text-color-primary)
+        
+  &.status-secondary
+    color: var(--product-status-text-color-secondary)
 
 .product-list-thumb-info
   line-height: normal


### PR DESCRIPTION
1. Add settings for primary vs secondary product status to be able to differentiate "on sale" vs other statuses
2. Created color combinations for primary vs secondary status for all style presets
3. Slight tweaks to the style presets to make the primary and secondary _background_ colors to be the same to make the presets more broadly appealing by default (vs how most were different)
4. Bump version to 2.8.1

Example from default
![image](https://github.com/user-attachments/assets/c5fd8b91-7d8c-4804-87ec-06c69d1a3401)

![image](https://github.com/user-attachments/assets/35890414-bd5e-4ae4-9cce-36b2816a144d)
