### PR TITLE
v2.12.0

### DIFF
--- a/.dugway.json.example
+++ b/.dugway.json.example
@@ -5,6 +5,6 @@
   "customization": {
     "background_color": "#336699",
     "featured_products": 10,
-    "twitter_username": "bigcartel"
+    "instagram_url": "https://instagram.com/bigcartel"
   }
 }

--- a/source/javascripts/product.js
+++ b/source/javascripts/product.js
@@ -35,6 +35,65 @@ $('.product-option-select').on('change',function() {
   enableAddButton(option_price);
 });
 
+function updateInventoryMessage(optionId = null) {
+  const product = window.bigcartel.product;
+  const messageElement = document.querySelector('[data-inventory-message]');
+
+  if (
+    !themeOptions?.showLowInventoryMessages ||
+    themeOptions.showInventoryBars ||
+    !messageElement
+  ) {
+    return;
+  }
+
+  messageElement.textContent = '';
+  const productOptions = product?.options || [];
+
+  // If no option is selected (initial page load or reset) or product has no options
+  if (!optionId) {
+    const hasOptionWithStatus = (status) => 
+      productOptions.length > 0 && 
+      productOptions.some(option => 
+        option && 
+        !option.sold_out && 
+        option[status]
+      );
+
+    // Single option product - check both statuses
+    if (productOptions.length === 1) {
+      const option = productOptions[0];
+      if (option && !option.sold_out) {
+        if (option.isAlmostSoldOut) {
+          messageElement.textContent = themeOptions.almostSoldOutMessage;
+        } else if (option.isLowInventory) {
+          messageElement.textContent = themeOptions.lowInventoryMessage;
+        }
+      }
+      return;
+    }
+
+    // Multiple options - only check for low inventory across all options
+    if (productOptions.length > 1 && hasOptionWithStatus('isLowInventory')) {
+      messageElement.textContent = themeOptions.lowInventoryMessage;
+    }
+    return;
+  }
+
+  // Handle selected option
+  const selectedOption = product.options.find(option => option.id === parseInt(optionId));
+  if (!selectedOption || selectedOption.sold_out) return;
+
+  // For selected options:
+  // - Single option products: check both almost sold out and low inventory
+  // - Multiple option products: check both statuses when specific option selected
+  if (selectedOption.isAlmostSoldOut) {
+    messageElement.textContent = themeOptions.almostSoldOutMessage;
+  } else if (selectedOption.isLowInventory) {
+    messageElement.textContent = themeOptions.lowInventoryMessage;
+  }
+}
+
 function enableAddButton(updated_price) {
   var addButton = $('.add-to-cart-button');
   var addButtonTitle = addButton.attr('data-add-title');
@@ -47,6 +106,7 @@ function enableAddButton(updated_price) {
   }
   addButton.html(addButtonTitle + priceTitle);
   addButton.attr('aria-label',addButton.text());
+  updateInventoryMessage($('#option').val());
 }
 
 function disableAddButton(type) {
@@ -98,3 +158,7 @@ function disableSelectOption(select_option, type) {
     }
   }
 }
+
+document.addEventListener('DOMContentLoaded', () => {
+  updateInventoryMessage();
+});

--- a/source/javascripts/product.js
+++ b/source/javascripts/product.js
@@ -28,19 +28,7 @@ if (themeOptions.productImageZoom === true) {
   });
   lightbox.init();
 }
-$(document).ready(function() {
-  if ($('.all-related-products').length) {
-    var num_products = $('.all-related-products .product-list-thumb').length;
-    var elements = $('.all-related-products').children().toArray();
-    var num_to_display = $('.related-products-container').data('num-products');
-    for (var i=1; i<=num_to_display; i++) {
-      var randomIndex = getRandomIndex(elements);
-      $('.related-product-list').append($('.all-related-products').children().eq(randomIndex));
-      elements.splice(randomIndex, 1);
-    }
-    $('.all-related-products').remove();
-  }
-});
+
 
 $('.product-option-select').on('change',function() {
   var option_price = $(this).find("option:selected").attr("data-price");

--- a/source/layout.html
+++ b/source/layout.html
@@ -159,7 +159,10 @@
 
     <footer data-bc-hook="footer">
       <div class="wrapper">
-        <nav class="footer-nav" id="footer" role="navigation" aria-label="Footer">
+        {% if theme.footer_text != blank and theme.footer_text_position == "start" %}
+          <div class="footer-custom-content">{{ theme.footer_text }} </div>
+        {% endif %}
+        <nav class="footer-nav footer-nav--main" role="navigation" aria-label="Footer main">
           <ul class="footer-links">
             <li><a href="/">{{ pages.home.name }}</a></li>
             <li><a href="/products">{{ pages.products.name }}</a></li>
@@ -270,6 +273,9 @@
                 <li><a href="{{ theme.bandcamp_url }}" title="Bandcamp"><svg class="bandcamp-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M349 406H0l163-300h349L349 406Z"/></svg></a></li>
               {% endif %}
             </ul>
+          {% endif %}
+          {% if theme.footer_text != blank and theme.footer_text_position == "end" %}
+            <div class="footer-custom-content">{{ theme.footer_text }} </div>
           {% endif %}
           {{ powered_by_big_cartel }}
         </nav>

--- a/source/layout.html
+++ b/source/layout.html
@@ -82,134 +82,78 @@
     </main>
     {% if page.full_url contains '/product/' %}
       {% if theme.show_similar_products %}
-        {% assign current_id = product.id | to_string %}
-        {% assign related_products_limit = theme.similar_products | default: 5 %}
-        {% assign final_product_permalinks = '' %}
-        
-        {% comment %}
-        Step 1: Collect Products from Categories
-        {% endcomment %}
-        {% if product.categories != blank %}
-          {% for category in product.categories limit: 4 %}
-            {% if current_count >= related_products_limit %}
-              {% break %}
-            {% endif %}
-            
-            {% for product in category.products | order: theme.similar_products_order %}
-              {% if current_count >= related_products_limit %}
-                {% break %}
+        {% assign related_products_header = theme.similar_products_header | default: 'You might also like' %}
+        {% assign related_products_collection = product.related_products %}
+
+        <aside class="related-products-container wrapper" data-num-products="{{ related_products_limit }}" role="complementary" aria-label="{{ related_products_header }}">
+          <div class="all-related-products" style="display: none"></div>
+          <div class="similar-products">
+            <div class="similar-products-header">
+              <h2 class="similar-products-title">{{ related_products_header }}</h2>
+              {% if product.previous_product != blank or product.next_product != blank %}
+                <ul class="prev-next-products">
+                  {% if product.previous_product != blank %}
+                    <li>{{ product.previous_product | link_to: "Previous product" }}</li>
+                  {% endif %}
+                  {% if product.next_product != blank %}
+                    <li>{{ product.next_product | link_to: "Next product" }}</li>
+                  {% endif %}
+                </ul>
               {% endif %}
-              
-              {% assign product_permalink = product.permalink %}
-              {% if product.id != current_id %}
-                {% assign product_permalinks_array = final_product_permalinks | split: ',' %}
-                {% unless product_permalinks_array contains product_permalink %}
-                  {% assign final_product_permalinks = final_product_permalinks | append: product_permalink | append: ',' %}
-                  {% assign current_count = current_count | plus: 1 %}
-                {% endunless %}
-              {% endif %}
-            {% endfor %}
-          {% endfor %}
-        {% endif %}
-        
-        {% comment %}
-        Step 2: Collect Fallback Products from products.all
-        {% endcomment %}
-        {% assign current_count = final_product_permalinks | split: ',' | size %}
-        {% assign remaining_limit = related_products_limit | minus: current_count %}
-        
-        {% if remaining_limit > 0 %}
-          {% paginate products from products.all by remaining_limit order: theme.similar_products_order %}
-            {% for product in products %}
-              {% assign product_permalink = product.permalink %}
-              {% if product.id != current_id %}
-                {% assign product_permalinks_array = final_product_permalinks | split: ',' %}
-                {% unless product_permalinks_array contains product_permalink %}
-                  {% assign final_product_permalinks = final_product_permalinks | append: product_permalink | append: ',' %}
-                {% endunless %}
-              {% endif %}
-            {% endfor %}
-          {% endpaginate %}
-        {% endif %}
-        
-        {% comment %}
-        Step 3: Render Final Products
-        {% endcomment %}
-        {% assign final_permalinks_array = final_product_permalinks | split: ',' %}
-        {% if final_permalinks_array.size > 0 %}
-          <aside class="related-products-container wrapper" data-num-products="{{ related_products_limit }}" role="complementary" aria-label="{{ theme.similar_products_header | default: 'You might also like' }}">
-            <div class="all-related-products" style="display: none"></div>
-            <div class="similar-products">
-              <div class="similar-products-header">
-                <h2 class="similar-products-title">{{ theme.similar_products_header | default: 'You might also like' }}</h2>
-                {% if product.previous_product != blank or product.next_product != blank %}
-                  <ul class="prev-next-products">
-                    {% if product.previous_product != blank %}
-                      <li>{{ product.previous_product | link_to: "Previous product" }}</li>
-                    {% endif %}
-                    {% if product.next_product != blank %}
-                      <li>{{ product.next_product | link_to: "Next product" }}</li>
-                    {% endif %}
-                  </ul>
-                {% endif %}
-              </div>
-              <div class="product-list-container">
-                <div class="related-product-list product-list">
-                  {% for product_permalink in final_permalinks_array %}
-                    {% assign matched_product = products[product_permalink] %}
-                    {% assign matched_product_status = '' %}
-                    {% case matched_product.status %} 
-                      {% when 'active' %} 
-                        {% if matched_product.on_sale %}{% assign matched_product_status = 'On sale' %}{% endif %} 
-                      {% when 'sold-out' %} 
-                        {% assign matched_product_status = 'Sold out' %} 
-                      {% when 'coming-soon' %} 
-                        {% assign matched_product_status = 'Coming soon' %} 
-                    {% endcase %}
-                    {% capture matched_product_status_class %}{% if matched_product.status == 'active' and matched_product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
-                    {% if matched_product != blank %}
-                      <div class="product-list-thumb {{ matched_product.css_class }}">
-                        <a class="product-list-link product-list-link--{{ theme.show_overlay }}" href="{{ matched_product.url }}" title="View {{ matched_product.name | escape }}">
-                          <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
-                            <img
-                              alt="{{ matched_product.name }}"
-                              class="blur-up product-list-image lazyload grid-{{ theme.grid_image_style }}"
-                              src="{{ matched_product.image | product_image_url | constrain: 20 }}"
-                              {% unless theme.grid_image_style == 'default' %}data-aspectratio="{{ matched_product.image.width | divided_by: matched_product.image.height }}"{% endunless %}
-                              data-srcset="
-                                {{ matched_product.image | product_image_url | constrain: 240 }} 240w,
-                                {{ matched_product.image | product_image_url | constrain: 320 }} 320w,
-                                {{ matched_product.image | product_image_url | constrain: 400 }} 400w,
-                                {{ matched_product.image | product_image_url | constrain: 540 }} 540w,
-                                {{ matched_product.image | product_image_url | constrain: 600 }} 600w,
-                                {{ matched_product.image | product_image_url | constrain: 800 }} 800w,
-                                {{ matched_product.image | product_image_url | constrain: 960 }} 960w
-                              "
-                              data-sizes="auto"
-                            >
-                          </div>
-                          <div class="product-list-thumb-info">
-                            <div class="product-list-thumb-name">{{ matched_product.name }}</div>
-                            <div class="product-list-thumb-price">
-                              {% unless matched_product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
-                                {% if matched_product.variable_pricing %}
-                                  {{ matched_product.min_price | money: theme.money_format }} - {{ matched_product.max_price | money: theme.money_format }}
-                                {% else %}
-                                  {{ matched_product.default_price | money: theme.money_format }}
-                                {% endif %}
-                              {% endunless %}
-                            </div>
-                            {% if matched_product_status != blank %}<div class="product-list-thumb-status {{ matched_product_status_class }}">{{ matched_product_status }}</div>{% endif %}
-                          </div>
-                        </a>
+            </div>
+            <div class="product-list-container">
+              <div class="related-product-list product-list">
+                {% for related_product in related_products_collection %}
+                  {% assign related_product_status = '' %}
+                  {% case related_product.status %} 
+                    {% when 'active' %} 
+                      {% if related_product.on_sale %}{% assign related_product_status = 'On sale' %}{% endif %} 
+                    {% when 'sold-out' %} 
+                      {% assign related_product_status = 'Sold out' %} 
+                    {% when 'coming-soon' %} 
+                      {% assign related_product_status = 'Coming soon' %} 
+                  {% endcase %}
+                  {% capture related_product_status_class %}{% if related_product.status == 'active' and related_product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
+                  <div class="product-list-thumb {{ related_product.css_class }}">
+                    <a class="product-list-link product-list-link--{{ theme.show_overlay }}" href="{{ related_product.url }}" title="View {{ related_product.name | escape }}">
+                      <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
+                        <img
+                          alt="{{ related_product.name }}"
+                          class="blur-up product-list-image lazyload grid-{{ theme.grid_image_style }}"
+                          src="{{ related_product.image | product_image_url | constrain: 20 }}"
+                          {% unless theme.grid_image_style == 'default' %}data-aspectratio="{{ related_product.image.width | divided_by: related_product.image.height }}"{% endunless %}
+                          data-srcset="
+                            {{ related_product.image | product_image_url | constrain: 240 }} 240w,
+                            {{ related_product.image | product_image_url | constrain: 320 }} 320w,
+                            {{ related_product.image | product_image_url | constrain: 400 }} 400w,
+                            {{ related_product.image | product_image_url | constrain: 540 }} 540w,
+                            {{ related_product.image | product_image_url | constrain: 600 }} 600w,
+                            {{ related_product.image | product_image_url | constrain: 800 }} 800w,
+                            {{ related_product.image | product_image_url | constrain: 960 }} 960w
+                          "
+                          data-sizes="auto"
+                        >
                       </div>
-                    {% endif %}
-                  {% endfor %}
-                </div>
+                      <div class="product-list-thumb-info">
+                        <div class="product-list-thumb-name">{{ related_product.name }}</div>
+                        <div class="product-list-thumb-price">
+                          {% unless related_product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+                            {% if related_product.variable_pricing %}
+                              {{ related_product.min_price | money: theme.money_format }} - {{ related_product.max_price | money: theme.money_format }}
+                            {% else %}
+                              {{ related_product.default_price | money: theme.money_format }}
+                            {% endif %}
+                          {% endunless %}
+                        </div>
+                        {% if related_product_status != blank %}<div class="product-list-thumb-status {{ related_product_status_class }}">{{ related_product_status }}</div>{% endif %}
+                      </div>
+                    </a>
+                  </div>
+                {% endfor %}
               </div>
             </div>
-          </aside>
-        {% endif %}
+          </div>
+        </aside>
       {% endif %}
     {% endif %}
 

--- a/source/layout.html
+++ b/source/layout.html
@@ -82,85 +82,121 @@
     </main>
     {% if page.full_url contains '/product/' %}
       {% if theme.show_similar_products %}
+        {% assign current_id = product.id | to_string %}
+        {% assign related_products_limit = theme.similar_products | default: 5 %}
+        {% assign final_product_permalinks = '' %}
+        
+        {% comment %}
+        Step 1: Collect Products from Categories
+        {% endcomment %}
         {% if product.categories != blank %}
-          {% assign current_id = product.id %}
-          {% for category in product.categories limit: 2 %}
-            {% capture product_divs %}
-              {% for product in category.products limit: 10 %}
+          {% for category in product.categories limit: 4 %}
+            {% for product in category.products | order: theme.similar_products_order %}
+              {% if final_product_permalinks | split: ',' | size < related_products_limit %}
+                {% assign product_permalink = product.permalink %}
                 {% if product.id != current_id %}
-                  {% assign image_width = product.image.width | times: 1.0 %}
-                  {% assign image_height = product.image.height | times: 1.0 %}
-                  {% assign aspect_ratio = image_width | divided_by: image_height %}
-                  {% assign product_status = '' %}
-                  {% case product.status %}
-                    {% when 'active' %}
-                      {% if product.on_sale %}{% assign product_status = 'On sale' %}{% endif %}
-                    {% when 'sold-out' %}
-                      {% assign product_status = 'Sold out' %}
-                    {% when 'coming-soon' %}
-                      {% assign product_status = 'Coming soon' %}
-                  {% endcase %}
-                  <div class="product-list-thumb {{ product.css_class }}">
-                    <a class="product-list-link product-list-link--{{ theme.show_overlay }}" href="{{ product.url }}" title="View {{ product.name | escape }}">
-                      <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
-                        <img
-                          alt=""
-                          class="blur-up product-list-image lazyload grid-{{ theme.grid_image_style }}"
-                          src="{{ product.image | product_image_url | constrain: 20 }}"
-                          {% unless theme.grid_image_style == 'default' %}data-aspectratio="{{ aspect_ratio }}"{% endunless %}
-                          data-srcset="
-                            {{ product.image | product_image_url | constrain: 240 }} 240w,
-                            {{ product.image | product_image_url | constrain: 320 }} 320w,
-                            {{ product.image | product_image_url | constrain: 400 }} 400w,
-                            {{ product.image | product_image_url | constrain: 540 }} 540w,
-                            {{ product.image | product_image_url | constrain: 600 }} 600w,
-                            {{ product.image | product_image_url | constrain: 800 }} 800w,
-                            {{ product.image | product_image_url | constrain: 960 }} 960w
-                          "
-                          data-sizes="auto"
-                        >
-                      </div>
-                      <div class="product-list-thumb-info">
-                        <div class="product-list-thumb-name">{{ product.name }}</div>
-                        <div class="product-list-thumb-price">
-                          {% unless product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
-                            {% if product.variable_pricing %}
-                              {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
-                            {% else %}
-                              {{ product.default_price | money: theme.money_format }}
-                            {% endif %}
-                          {% endunless %}
-                        </div>
-                      </div>
-                    </a>
-                  </div>
+                  {% assign product_permalinks_array = final_product_permalinks | split: ',' %}
+                  {% unless product_permalinks_array contains product_permalink %}
+                    {% assign final_product_permalinks = final_product_permalinks | append: product_permalink | append: ',' %}
+                  {% endunless %}
                 {% endif %}
-              {% endfor %}
-            {% endcapture %}
+              {% else %}
+                {% break %}
+              {% endif %}
+            {% endfor %}
           {% endfor %}
+        {% endif %}
+        
+        {% comment %}
+        Step 2: Collect Fallback Products from products.all
+        {% endcomment %}
+        {% assign current_count = final_product_permalinks | split: ',' | size %}
+        {% assign remaining_limit = related_products_limit | minus: current_count %}
+        
+        {% if remaining_limit > 0 %}
+          {% paginate products from products.all by remaining_limit order: theme.similar_products_order %}
+            {% for product in products %}
+              {% assign product_permalink = product.permalink %}
+              {% if product.id != current_id %}
+                {% assign product_permalinks_array = final_product_permalinks | split: ',' %}
+                {% unless product_permalinks_array contains product_permalink %}
+                  {% assign final_product_permalinks = final_product_permalinks | append: product_permalink | append: ',' %}
+                {% endunless %}
+              {% endif %}
+            {% endfor %}
+          {% endpaginate %}
+        {% endif %}
+        
+        {% comment %}
+        Step 3: Render Final Products
+        {% endcomment %}
+        {% assign final_permalinks_array = final_product_permalinks | split: ',' %}
+        {% if final_permalinks_array.size > 0 %}
+          <aside class="related-products-container wrapper" data-num-products="{{ related_products_limit }}" role="complementary" aria-label="{{ theme.similar_products_header | default: 'Related Products' }}">
+            <div class="all-related-products" style="display: none"></div>
+            <div class="similar-products">
+              <div class="similar-products-header">
+                <h2 class="similar-products-title">{{ theme.similar_products_header | default: 'Related products' }}</h2>
+                {% if product.previous_product != blank or product.next_product != blank %}
+                  <ul class="prev-next-products">
+                    {% if product.previous_product != blank %}
+                      <li>{{ product.previous_product | link_to: "Previous product" }}</li>
+                    {% endif %}
+                    {% if product.next_product != blank %}
+                      <li>{{ product.next_product | link_to: "Next product" }}</li>
+                    {% endif %}
+                  </ul>
+                {% endif %}
+              </div>
+              <div class="product-list-container">
+                <div class="related-product-list product-list">
+                  {% for product_permalink in final_permalinks_array %}
+                    {% assign matched_product = products[product_permalink] %}
+                    
+                    {% if matched_product != blank %}
+                      <div class="product-list-thumb {{ matched_product.css_class }}">
+                        <a class="product-list-link product-list-link--{{ theme.show_overlay }}" href="{{ matched_product.url }}" title="View {{ matched_product.name | escape }}">
+                          <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
+                            <img
+                              alt="{{ matched_product.name }}"
+                              class="blur-up product-list-image lazyload grid-{{ theme.grid_image_style }}"
+                              src="{{ matched_product.image | product_image_url | constrain: 20 }}"
+                              {% unless theme.grid_image_style == 'default' %}data-aspectratio="{{ matched_product.image.width | divided_by: matched_product.image.height }}"{% endunless %}
+                              data-srcset="
+                                {{ matched_product.image | product_image_url | constrain: 240 }} 240w,
+                                {{ matched_product.image | product_image_url | constrain: 320 }} 320w,
+                                {{ matched_product.image | product_image_url | constrain: 400 }} 400w,
+                                {{ matched_product.image | product_image_url | constrain: 540 }} 540w,
+                                {{ matched_product.image | product_image_url | constrain: 600 }} 600w,
+                                {{ matched_product.image | product_image_url | constrain: 800 }} 800w,
+                                {{ matched_product.image | product_image_url | constrain: 960 }} 960w
+                              "
+                              data-sizes="auto"
+                            >
+                          </div>
+                          <div class="product-list-thumb-info">
+                            <div class="product-list-thumb-name">{{ matched_product.name }}</div>
+                            <div class="product-list-thumb-price">
+                              {% unless matched_product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+                                {% if matched_product.variable_pricing %}
+                                  {{ matched_product.min_price | money: theme.money_format }} - {{ matched_product.max_price | money: theme.money_format }}
+                                {% else %}
+                                  {{ matched_product.default_price | money: theme.money_format }}
+                                {% endif %}
+                              {% endunless %}
+                            </div>
+                          </div>
+                        </a>
+                      </div>
+                    {% endif %}
+                  {% endfor %}
+                </div>
+              </div>
+            </div>
+          </aside>
         {% endif %}
       {% endif %}
     {% endif %}
-    {% if product_divs != blank %}
-      <aside class="related-products-container wrapper" data-num-products="3" role="complementary" aria-label="Related Products">
-        <div class="all-related-products" style="display: none">{{ product_divs }}</div>
-        <div class="similar-products">
-          <div class="similar-products-header">
-            <h2 class="similar-products-title">Related products</h2>
-            {% if product.previous_product != blank or product.next_product != blank %}
-              <ul class="prev-next-products">
-                {% if product.previous_product != blank %}<li>{{ product.previous_product | link_to: "Previous product" }}</li>{% endif %}
-                {% if product.next_product != blank %}<li>{{ product.next_product | link_to: "Next product" }}</li>{% endif %}
-              </ul>
-            {% endif %}
-          </div>
-          <div class="product-list-container">
-            <div class="related-product-list product-list"></div>
-          </div>
-        </div>
-      </aside>
-    {% endif %}
-
 
 
     <footer data-bc-hook="footer">

--- a/source/layout.html
+++ b/source/layout.html
@@ -86,7 +86,6 @@
         {% assign related_products_collection = product.related_products %}
 
         <aside class="related-products-container wrapper" data-num-products="{{ related_products_limit }}" role="complementary" aria-label="{{ related_products_header }}">
-          <div class="all-related-products" style="display: none"></div>
           <div class="similar-products">
             <div class="similar-products-header">
               <h2 class="similar-products-title">{{ related_products_header }}</h2>
@@ -171,25 +170,24 @@
           </ul>
         </nav>
         {% if categories.active.size > 0 and show_categories_in_footer == true %}
-        <nav class="footer-nav footer-nav--categories" role="navigation" aria-label="Footer categories">
-          
-          <ul class="footer-links">
-            {% for category in categories.active %}
-              <li>{{ category | link_to }}</li>
-            {% endfor %}
-          </ul>
-        </nav>
+          <nav class="footer-nav footer-nav--categories" role="navigation" aria-label="Footer categories">
+            <ul class="footer-links">
+              {% for category in categories.active %}
+                <li>{{ category | link_to }}</li>
+              {% endfor %}
+            </ul>
+          </nav>
         {% endif %}
-        <nav class="footer-nav footer-nav--pages" role="navigation" aria-label="Footer pages">
-          {% if pages.all.size > 0 %}
-          <ul class="footer-links">
-            {% for page in pages.all %}
-              <li>{{ page | link_to }}</li>
-            {% endfor %}
-          </ul>
-        </nav>
+        {% if pages.all.size > 0 %}
+          <nav class="footer-nav footer-nav--pages" role="navigation" aria-label="Footer pages">
+            <ul class="footer-links">
+              {% for page in pages.all %}
+                <li>{{ page | link_to }}</li>
+              {% endfor %}
+            </ul>
+          </nav>
+        {% endif %}
         <nav class="footer-nav footer-nav--social" role="navigation" aria-label="Footer social">
-          {% endif %}
           {% if theme.show_search %}
             <div class="footer-search">
               <form class="search-form" name="search" action="/products" method="get" accept-charset="utf8" role="search">

--- a/source/layout.html
+++ b/source/layout.html
@@ -254,9 +254,6 @@
               {% endif %}
             </ul>
           {% endif %}
-          {% if store.website != blank %}
-            <a href="{{ store.website }}" class="button back-to-site" class="button">Back to site</a>
-          {% endif %}
           {{ powered_by_big_cartel }}
         </nav>
       </div>

--- a/source/layout.html
+++ b/source/layout.html
@@ -152,7 +152,16 @@
                 <div class="related-product-list product-list">
                   {% for product_permalink in final_permalinks_array %}
                     {% assign matched_product = products[product_permalink] %}
-                    
+                    {% assign matched_product_status = '' %}
+                    {% case matched_product.status %} 
+                      {% when 'active' %} 
+                        {% if matched_product.on_sale %}{% assign matched_product_status = 'On sale' %}{% endif %} 
+                      {% when 'sold-out' %} 
+                        {% assign matched_product_status = 'Sold out' %} 
+                      {% when 'coming-soon' %} 
+                        {% assign matched_product_status = 'Coming soon' %} 
+                    {% endcase %}
+                    {% capture matched_product_status_class %}{% if matched_product.status == 'active' and matched_product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
                     {% if matched_product != blank %}
                       <div class="product-list-thumb {{ matched_product.css_class }}">
                         <a class="product-list-link product-list-link--{{ theme.show_overlay }}" href="{{ matched_product.url }}" title="View {{ matched_product.name | escape }}">
@@ -185,6 +194,7 @@
                                 {% endif %}
                               {% endunless %}
                             </div>
+                            {% if matched_product_status != blank %}<div class="product-list-thumb-status {{ matched_product_status_class }}">{{ matched_product_status }}</div>{% endif %}
                           </div>
                         </a>
                       </div>

--- a/source/layout.html
+++ b/source/layout.html
@@ -157,19 +157,36 @@
       {% endif %}
     {% endif %}
 
-
     <footer data-bc-hook="footer">
       <div class="wrapper">
         <nav class="footer-nav" id="footer" role="navigation" aria-label="Footer">
           <ul class="footer-links">
             <li><a href="/">{{ pages.home.name }}</a></li>
             <li><a href="/products">{{ pages.products.name }}</a></li>
-            {% for page in pages.all %}
-              <li>{{ page | link_to }}</li>
-            {% endfor %}
             <li><a href="/contact">{{ pages.contact.name }}</a></li>
             <li><a href="/cart">{{ pages.cart.name }}</a></li>
           </ul>
+        </nav>
+        {% if categories.active.size > 0 and show_categories_in_footer == true %}
+        <nav class="footer-nav footer-nav--categories" role="navigation" aria-label="Footer categories">
+          
+          <ul class="footer-links">
+            {% for category in categories.active %}
+              <li>{{ category | link_to }}</li>
+            {% endfor %}
+          </ul>
+        </nav>
+        {% endif %}
+        <nav class="footer-nav footer-nav--pages" role="navigation" aria-label="Footer pages">
+          {% if pages.all.size > 0 %}
+          <ul class="footer-links">
+            {% for page in pages.all %}
+              <li>{{ page | link_to }}</li>
+            {% endfor %}
+          </ul>
+        </nav>
+        <nav class="footer-nav footer-nav--social" role="navigation" aria-label="Footer social">
+          {% endif %}
           {% if theme.show_search %}
             <div class="footer-search">
               <form class="search-form" name="search" action="/products" method="get" accept-charset="utf8" role="search">

--- a/source/layout.html
+++ b/source/layout.html
@@ -196,9 +196,10 @@
             or theme.facebook_url != blank
             or theme.pinterest_url != blank
             or theme.youtube_url != blank
+            or theme.spotify_url != blank
+            or theme.linkedin_url != blank
             or theme.tumblr_url != blank
-            or theme.bandcamp_url != blank
-            or theme.linkedin_url != blank %}
+            or theme.bandcamp_url != blank %}
             <ul class="social-links">
               {% if theme.instagram_url != blank %}
                 <li><a href="{{ theme.instagram_url }}" title="Instagram"><svg class="instagram-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M256 45.39c67.27 0 75.23.26 101.8 1.47 24.56 1.12 37.9 5.22 46.78 8.67a78 78 0 0129 18.85 78 78 0 0118.85 29c3.45 8.88 7.55 22.22 8.67 46.78 1.21 26.57 1.47 34.53 1.47 101.8s-.26 75.23-1.47 101.8c-1.12 24.56-5.22 37.9-8.67 46.78a83.51 83.51 0 01-47.81 47.81c-8.88 3.45-22.22 7.55-46.78 8.67-26.56 1.21-34.53 1.47-101.8 1.47s-75.24-.26-101.8-1.47c-24.56-1.12-37.9-5.22-46.78-8.67a78 78 0 01-29-18.85 78 78 0 01-18.85-29c-3.45-8.88-7.55-22.22-8.67-46.78-1.21-26.57-1.47-34.53-1.47-101.8s.26-75.23 1.47-101.8c1.12-24.56 5.22-37.9 8.67-46.78a78 78 0 0118.85-29 78 78 0 0129-18.85c8.88-3.45 22.22-7.55 46.78-8.67 26.57-1.21 34.53-1.47 101.8-1.47m0-45.39c-68.42 0-77 .29-103.87 1.52S102.92 7 86.92 13.22a123.68 123.68 0 00-44.64 29.06 123.68 123.68 0 00-29.06 44.64c-6.22 16-10.48 34.34-11.7 61.15S0 183.5 0 256s.29 77 1.52 103.87 5.48 45.13 11.7 61.13a123.68 123.68 0 0029.06 44.62 123.52 123.52 0 0044.64 29.07c16 6.23 34.34 10.49 61.15 11.71s35.45 1.52 103.87 1.52 77-.29 103.87-1.52 45.11-5.48 61.11-11.71a128.74 128.74 0 0073.69-73.69c6.23-16 10.49-34.34 11.71-61.15s1.52-35.45 1.52-103.87-.29-77-1.52-103.87-5.48-45.11-11.71-61.11a123.52 123.52 0 00-29.05-44.62 123.68 123.68 0 00-44.64-29.08c-16-6.22-34.34-10.48-61.15-11.7S320.34 0 251.92 0z"/><path fill="currentColor" d="M251.92 122.56a129.36 129.36 0 10129.36 129.36 129.35 129.35 0 00-129.36-129.36zm0 213.36a84 84 0 1184-84 84 84 0 01-84 84z"/><circle fill="currentColor" cx="386.4" cy="117.44" r="30.23"/></svg></a></li>
@@ -236,16 +237,20 @@
                 <li><a href="{{ theme.youtube_url }}" title="YouTube"><svg class="youtube-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><path fill="currentColor" d="M550 124c-7-24-25-42-49-49-42-11-213-11-213-11S117 64 75 76c-24 6-42 24-49 48-11 43-11 132-11 132s0 90 11 133c7 23 25 41 49 47 42 12 213 12 213 12s171 0 213-11c24-7 42-25 49-48 11-43 11-133 11-133s0-89-11-132zM232 338V175l143 81-143 82z"/></svg></a></li>
               {% endif %}
 
+              {% if theme.spotify_url != blank %}
+                <li><a href="{{ theme.spotify_url }}" title="Spotify"><svg class="spotify-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 496 512"><path fill="currentColor" d="M248 8C111.1 8 0 119.1 0 256s111.1 248 248 248 248-111.1 248-248S384.9 8 248 8zm100.7 364.9c-4.2 0-6.8-1.3-10.7-3.6-62.4-37.6-135-39.2-206.7-24.5-3.9 1-9 2.6-11.9 2.6-9.7 0-15.8-7.7-15.8-15.8 0-10.3 6.1-15.2 13.6-16.8 81.9-18.1 165.6-16.5 237 26.2 6.1 3.9 9.7 7.4 9.7 16.5s-7.1 15.4-15.2 15.4zm26.9-65.6c-5.2 0-8.7-2.3-12.3-4.2-62.5-37-155.7-51.9-238.6-29.4-4.8 1.3-7.4 2.6-11.9 2.6-10.7 0-19.4-8.7-19.4-19.4s5.2-17.8 15.5-20.7c27.8-7.8 56.2-13.6 97.8-13.6 64.9 0 127.6 16.1 177 45.5 8.1 4.8 11.3 11 11.3 19.7-.1 10.8-8.5 19.5-19.4 19.5zm31-76.2c-5.2 0-8.4-1.3-12.9-3.9-71.2-42.5-198.5-52.7-280.9-29.7-3.6 1-8.1 2.6-12.9 2.6-13.2 0-23.3-10.3-23.3-23.6 0-13.6 8.4-21.3 17.4-23.9 35.2-10.3 74.6-15.2 117.5-15.2 73 0 149.5 15.2 205.4 47.8 7.8 4.5 12.9 10.7 12.9 22.6 0 13.6-11 23.3-23.2 23.3z"/></svg></a></li>
+              {% endif %}
+
+              {% if theme.linkedin_url != blank %}
+                <li><a href="{{ theme.linkedin_url }}" title="LinkedIn"><svg class="linkedin-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"/></svg></a></li>
+              {% endif %}
+
               {% if theme.tumblr_url != blank %}
                 <li><a href="{{ theme.tumblr_url }}" title="Tumblr"><svg class="tumblr-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path fill="currentColor" d="M310 480c-14 15-50 32-98 32-120 0-147-89-147-141V227H18c-6 0-10-4-10-10v-68c0-7 4-13 11-16 62-21 82-76 85-117 0-11 6-16 16-16h71c5 0 10 4 10 10v115h83c5 0 10 5 10 10v82c0 5-5 10-10 10h-84v133c0 34 24 54 68 36 5-2 9-3 13-2 3 1 6 3 7 8l22 64c2 5 3 10 0 14z"/></svg></a></li>
               {% endif %}
 
               {% if theme.bandcamp_url != blank %}
                 <li><a href="{{ theme.bandcamp_url }}" title="Bandcamp"><svg class="bandcamp-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M349 406H0l163-300h349L349 406Z"/></svg></a></li>
-              {% endif %}
-
-              {% if theme.linkedin_url != blank %}
-                <li><a href="{{ theme.linkedin_url }}" title="LinkedIn"><svg class="linkedin-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"/></svg></a></li>
               {% endif %}
             </ul>
           {% endif %}

--- a/source/layout.html
+++ b/source/layout.html
@@ -132,11 +132,11 @@
         {% endcomment %}
         {% assign final_permalinks_array = final_product_permalinks | split: ',' %}
         {% if final_permalinks_array.size > 0 %}
-          <aside class="related-products-container wrapper" data-num-products="{{ related_products_limit }}" role="complementary" aria-label="{{ theme.similar_products_header | default: 'Related Products' }}">
+          <aside class="related-products-container wrapper" data-num-products="{{ related_products_limit }}" role="complementary" aria-label="{{ theme.similar_products_header | default: 'You might also like' }}">
             <div class="all-related-products" style="display: none"></div>
             <div class="similar-products">
               <div class="similar-products-header">
-                <h2 class="similar-products-title">{{ theme.similar_products_header | default: 'Related products' }}</h2>
+                <h2 class="similar-products-title">{{ theme.similar_products_header | default: 'You might also like' }}</h2>
                 {% if product.previous_product != blank or product.next_product != blank %}
                   <ul class="prev-next-products">
                     {% if product.previous_product != blank %}

--- a/source/layout.html
+++ b/source/layout.html
@@ -290,6 +290,10 @@
       const themeOptions = {
         showSoldOutOptions: {{ theme.show_sold_out_product_options }},
         showSoldOutPrices: {{ theme.show_sold_out_product_prices }},
+        showLowInventoryMessages: {{ theme.show_low_inventory_messages }},
+        lowInventoryMessage: '{{ theme.low_inventory_message }}',
+        almostSoldOutMessage: '{{ theme.almost_sold_out_message }}',
+        showInventoryBars: {{ theme.show_inventory_bars }},
         desktopProductPageImages: '{{ theme.desktop_product_page_images }}',
         mobileProductPageImages: '{{ theme.mobile_product_page_images }}',
         productImageZoom: {{ theme.product_image_zoom }},

--- a/source/layout.html
+++ b/source/layout.html
@@ -85,74 +85,76 @@
         {% assign related_products_header = theme.similar_products_header | default: 'You might also like' %}
         {% assign related_products_collection = product.related_products %}
 
-        <aside class="related-products-container wrapper" data-num-products="{{ related_products_limit }}" role="complementary" aria-label="{{ related_products_header }}">
-          <div class="similar-products">
-            <div class="similar-products-header">
-              <h2 class="similar-products-title">{{ related_products_header }}</h2>
-              {% if product.previous_product != blank or product.next_product != blank %}
-                <ul class="prev-next-products">
-                  {% if product.previous_product != blank %}
-                    <li>{{ product.previous_product | link_to: "Previous product" }}</li>
-                  {% endif %}
-                  {% if product.next_product != blank %}
-                    <li>{{ product.next_product | link_to: "Next product" }}</li>
-                  {% endif %}
-                </ul>
-              {% endif %}
-            </div>
-            <div class="product-list-container">
-              <div class="related-product-list product-list">
-                {% for related_product in related_products_collection %}
-                  {% assign related_product_status = '' %}
-                  {% case related_product.status %} 
-                    {% when 'active' %} 
-                      {% if related_product.on_sale %}{% assign related_product_status = 'On sale' %}{% endif %} 
-                    {% when 'sold-out' %} 
-                      {% assign related_product_status = 'Sold out' %} 
-                    {% when 'coming-soon' %} 
-                      {% assign related_product_status = 'Coming soon' %} 
-                  {% endcase %}
-                  {% capture related_product_status_class %}{% if related_product.status == 'active' and related_product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
-                  <div class="product-list-thumb {{ related_product.css_class }}">
-                    <a class="product-list-link product-list-link--{{ theme.show_overlay }}" href="{{ related_product.url }}" title="View {{ related_product.name | escape }}">
-                      <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
-                        <img
-                          alt="{{ related_product.name }}"
-                          class="blur-up product-list-image lazyload grid-{{ theme.grid_image_style }}"
-                          src="{{ related_product.image | product_image_url | constrain: 20 }}"
-                          {% unless theme.grid_image_style == 'default' %}data-aspectratio="{{ related_product.image.width | divided_by: related_product.image.height }}"{% endunless %}
-                          data-srcset="
-                            {{ related_product.image | product_image_url | constrain: 240 }} 240w,
-                            {{ related_product.image | product_image_url | constrain: 320 }} 320w,
-                            {{ related_product.image | product_image_url | constrain: 400 }} 400w,
-                            {{ related_product.image | product_image_url | constrain: 540 }} 540w,
-                            {{ related_product.image | product_image_url | constrain: 600 }} 600w,
-                            {{ related_product.image | product_image_url | constrain: 800 }} 800w,
-                            {{ related_product.image | product_image_url | constrain: 960 }} 960w
-                          "
-                          data-sizes="auto"
-                        >
-                      </div>
-                      <div class="product-list-thumb-info">
-                        <div class="product-list-thumb-name">{{ related_product.name }}</div>
-                        <div class="product-list-thumb-price">
-                          {% unless related_product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
-                            {% if related_product.variable_pricing %}
-                              {{ related_product.min_price | money: theme.money_format }} - {{ related_product.max_price | money: theme.money_format }}
-                            {% else %}
-                              {{ related_product.default_price | money: theme.money_format }}
-                            {% endif %}
-                          {% endunless %}
+        {% if related_products_collection.size > 0 %}
+          <aside class="related-products-container wrapper" data-num-products="{{ related_products_limit }}" role="complementary" aria-label="{{ related_products_header }}">
+            <div class="similar-products">
+              <div class="similar-products-header">
+                <h2 class="similar-products-title">{{ related_products_header }}</h2>
+                {% if product.previous_product != blank or product.next_product != blank %}
+                  <ul class="prev-next-products">
+                    {% if product.previous_product != blank %}
+                      <li>{{ product.previous_product | link_to: "Previous product" }}</li>
+                    {% endif %}
+                    {% if product.next_product != blank %}
+                      <li>{{ product.next_product | link_to: "Next product" }}</li>
+                    {% endif %}
+                  </ul>
+                {% endif %}
+              </div>
+              <div class="product-list-container">
+                <div class="related-product-list product-list">
+                  {% for related_product in related_products_collection %}
+                    {% assign related_product_status = '' %}
+                    {% case related_product.status %} 
+                      {% when 'active' %} 
+                        {% if related_product.on_sale %}{% assign related_product_status = 'On sale' %}{% endif %} 
+                      {% when 'sold-out' %} 
+                        {% assign related_product_status = 'Sold out' %} 
+                      {% when 'coming-soon' %} 
+                        {% assign related_product_status = 'Coming soon' %} 
+                    {% endcase %}
+                    {% capture related_product_status_class %}{% if related_product.status == 'active' and related_product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
+                    <div class="product-list-thumb {{ related_product.css_class }}">
+                      <a class="product-list-link product-list-link--{{ theme.show_overlay }}" href="{{ related_product.url }}" title="View {{ related_product.name | escape }}">
+                        <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
+                          <img
+                            alt="{{ related_product.name }}"
+                            class="blur-up product-list-image lazyload grid-{{ theme.grid_image_style }}"
+                            src="{{ related_product.image | product_image_url | constrain: 20 }}"
+                            {% unless theme.grid_image_style == 'default' %}data-aspectratio="{{ related_product.image.width | divided_by: related_product.image.height }}"{% endunless %}
+                            data-srcset="
+                              {{ related_product.image | product_image_url | constrain: 240 }} 240w,
+                              {{ related_product.image | product_image_url | constrain: 320 }} 320w,
+                              {{ related_product.image | product_image_url | constrain: 400 }} 400w,
+                              {{ related_product.image | product_image_url | constrain: 540 }} 540w,
+                              {{ related_product.image | product_image_url | constrain: 600 }} 600w,
+                              {{ related_product.image | product_image_url | constrain: 800 }} 800w,
+                              {{ related_product.image | product_image_url | constrain: 960 }} 960w
+                            "
+                            data-sizes="auto"
+                          >
                         </div>
-                        {% if related_product_status != blank %}<div class="product-list-thumb-status {{ related_product_status_class }}">{{ related_product_status }}</div>{% endif %}
-                      </div>
-                    </a>
-                  </div>
-                {% endfor %}
+                        <div class="product-list-thumb-info">
+                          <div class="product-list-thumb-name">{{ related_product.name }}</div>
+                          <div class="product-list-thumb-price">
+                            {% unless related_product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+                              {% if related_product.variable_pricing %}
+                                {{ related_product.min_price | money: theme.money_format }} - {{ related_product.max_price | money: theme.money_format }}
+                              {% else %}
+                                {{ related_product.default_price | money: theme.money_format }}
+                              {% endif %}
+                            {% endunless %}
+                          </div>
+                          {% if related_product_status != blank %}<div class="product-list-thumb-status {{ related_product_status_class }}">{{ related_product_status }}</div>{% endif %}
+                        </div>
+                      </a>
+                    </div>
+                  {% endfor %}
+                </div>
               </div>
             </div>
-          </div>
-        </aside>
+          </aside>
+        {% endif %}
       {% endif %}
     {% endif %}
 

--- a/source/layout.html
+++ b/source/layout.html
@@ -91,17 +91,22 @@
         {% endcomment %}
         {% if product.categories != blank %}
           {% for category in product.categories limit: 4 %}
+            {% if current_count >= related_products_limit %}
+              {% break %}
+            {% endif %}
+            
             {% for product in category.products | order: theme.similar_products_order %}
-              {% if final_product_permalinks | split: ',' | size < related_products_limit %}
-                {% assign product_permalink = product.permalink %}
-                {% if product.id != current_id %}
-                  {% assign product_permalinks_array = final_product_permalinks | split: ',' %}
-                  {% unless product_permalinks_array contains product_permalink %}
-                    {% assign final_product_permalinks = final_product_permalinks | append: product_permalink | append: ',' %}
-                  {% endunless %}
-                {% endif %}
-              {% else %}
+              {% if current_count >= related_products_limit %}
                 {% break %}
+              {% endif %}
+              
+              {% assign product_permalink = product.permalink %}
+              {% if product.id != current_id %}
+                {% assign product_permalinks_array = final_product_permalinks | split: ',' %}
+                {% unless product_permalinks_array contains product_permalink %}
+                  {% assign final_product_permalinks = final_product_permalinks | append: product_permalink | append: ',' %}
+                  {% assign current_count = current_count | plus: 1 %}
+                {% endunless %}
               {% endif %}
             {% endfor %}
           {% endfor %}

--- a/source/layout.html
+++ b/source/layout.html
@@ -198,6 +198,7 @@
             or theme.youtube_url != blank
             or theme.spotify_url != blank
             or theme.linkedin_url != blank
+            or theme.twitch_url != blank
             or theme.tumblr_url != blank
             or theme.bandcamp_url != blank %}
             <ul class="social-links">
@@ -243,6 +244,10 @@
 
               {% if theme.linkedin_url != blank %}
                 <li><a href="{{ theme.linkedin_url }}" title="LinkedIn"><svg class="linkedin-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"/></svg></a></li>
+              {% endif %}
+
+              {% if theme.twitch_url != blank %}
+                <li><a href="{{ theme.twitch_url }}" title="Twitch"><svg class="twitch-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M391.2 103.5H352.5v109.7h38.6zM285 103H246.4V212.8H285zM120.8 0 24.3 91.4V420.6H140.1V512l96.5-91.4h77.3L487.7 256V0zM449.1 237.8l-77.2 73.1H294.6l-67.6 64v-64H140.1V36.6H449.1z"/></svg></a></li>
               {% endif %}
 
               {% if theme.tumblr_url != blank %}

--- a/source/maintenance.html
+++ b/source/maintenance.html
@@ -20,9 +20,10 @@
           or theme.facebook_url != blank
           or theme.pinterest_url != blank
           or theme.youtube_url != blank
+          or theme.spotify_url != blank
+          or theme.linkedin_url != blank
           or theme.tumblr_url != blank
-          or theme.bandcamp_url != blank
-          or theme.linkedin_url !=  blank %}
+          or theme.bandcamp_url != blank %}
         <ul class="social-links">
           {% if theme.instagram_url != blank %}
             <li><a href="{{ theme.instagram_url }}" title="Instagram"><svg class="instagram-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M256 45.39c67.27 0 75.23.26 101.8 1.47 24.56 1.12 37.9 5.22 46.78 8.67a78 78 0 0129 18.85 78 78 0 0118.85 29c3.45 8.88 7.55 22.22 8.67 46.78 1.21 26.57 1.47 34.53 1.47 101.8s-.26 75.23-1.47 101.8c-1.12 24.56-5.22 37.9-8.67 46.78a83.51 83.51 0 01-47.81 47.81c-8.88 3.45-22.22 7.55-46.78 8.67-26.56 1.21-34.53 1.47-101.8 1.47s-75.24-.26-101.8-1.47c-24.56-1.12-37.9-5.22-46.78-8.67a78 78 0 01-29-18.85 78 78 0 01-18.85-29c-3.45-8.88-7.55-22.22-8.67-46.78-1.21-26.57-1.47-34.53-1.47-101.8s.26-75.23 1.47-101.8c1.12-24.56 5.22-37.9 8.67-46.78a78 78 0 0118.85-29 78 78 0 0129-18.85c8.88-3.45 22.22-7.55 46.78-8.67 26.57-1.21 34.53-1.47 101.8-1.47m0-45.39c-68.42 0-77 .29-103.87 1.52S102.92 7 86.92 13.22a123.68 123.68 0 00-44.64 29.06 123.68 123.68 0 00-29.06 44.64c-6.22 16-10.48 34.34-11.7 61.15S0 183.5 0 256s.29 77 1.52 103.87 5.48 45.13 11.7 61.13a123.68 123.68 0 0029.06 44.62 123.52 123.52 0 0044.64 29.07c16 6.23 34.34 10.49 61.15 11.71s35.45 1.52 103.87 1.52 77-.29 103.87-1.52 45.11-5.48 61.11-11.71a128.74 128.74 0 0073.69-73.69c6.23-16 10.49-34.34 11.71-61.15s1.52-35.45 1.52-103.87-.29-77-1.52-103.87-5.48-45.11-11.71-61.11a123.52 123.52 0 00-29.05-44.62 123.68 123.68 0 00-44.64-29.08c-16-6.22-34.34-10.48-61.15-11.7S320.34 0 251.92 0z"/><path fill="currentColor" d="M251.92 122.56a129.36 129.36 0 10129.36 129.36 129.35 129.35 0 00-129.36-129.36zm0 213.36a84 84 0 1184-84 84 84 0 01-84 84z"/><circle fill="currentColor" cx="386.4" cy="117.44" r="30.23"/></svg></a></li>
@@ -60,16 +61,20 @@
             <li><a href="{{ theme.youtube_url }}" title="YouTube"><svg class="youtube-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><path fill="currentColor" d="M550 124c-7-24-25-42-49-49-42-11-213-11-213-11S117 64 75 76c-24 6-42 24-49 48-11 43-11 132-11 132s0 90 11 133c7 23 25 41 49 47 42 12 213 12 213 12s171 0 213-11c24-7 42-25 49-48 11-43 11-133 11-133s0-89-11-132zM232 338V175l143 81-143 82z"/></svg></a></li>
           {% endif %}
 
+          {% if theme.spotify_url != blank %}
+            <li><a href="{{ theme.spotify_url }}" title="Spotify"><svg class="spotify-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 496 512"><path fill="currentColor" d="M248 8C111.1 8 0 119.1 0 256s111.1 248 248 248 248-111.1 248-248S384.9 8 248 8zm100.7 364.9c-4.2 0-6.8-1.3-10.7-3.6-62.4-37.6-135-39.2-206.7-24.5-3.9 1-9 2.6-11.9 2.6-9.7 0-15.8-7.7-15.8-15.8 0-10.3 6.1-15.2 13.6-16.8 81.9-18.1 165.6-16.5 237 26.2 6.1 3.9 9.7 7.4 9.7 16.5s-7.1 15.4-15.2 15.4zm26.9-65.6c-5.2 0-8.7-2.3-12.3-4.2-62.5-37-155.7-51.9-238.6-29.4-4.8 1.3-7.4 2.6-11.9 2.6-10.7 0-19.4-8.7-19.4-19.4s5.2-17.8 15.5-20.7c27.8-7.8 56.2-13.6 97.8-13.6 64.9 0 127.6 16.1 177 45.5 8.1 4.8 11.3 11 11.3 19.7-.1 10.8-8.5 19.5-19.4 19.5zm31-76.2c-5.2 0-8.4-1.3-12.9-3.9-71.2-42.5-198.5-52.7-280.9-29.7-3.6 1-8.1 2.6-12.9 2.6-13.2 0-23.3-10.3-23.3-23.6 0-13.6 8.4-21.3 17.4-23.9 35.2-10.3 74.6-15.2 117.5-15.2 73 0 149.5 15.2 205.4 47.8 7.8 4.5 12.9 10.7 12.9 22.6 0 13.6-11 23.3-23.2 23.3z"/></svg></a></li>
+          {% endif %}
+
+          {% if theme.linkedin_url != blank %}
+            <li><a href="{{ theme.linkedin_url }}" title="LinkedIn"><svg class="linkedin-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"/></svg></a></li>
+          {% endif %}
+
           {% if theme.tumblr_url != blank %}
             <li><a href="{{ theme.tumblr_url }}" title="Tumblr"><svg class="tumblr-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path fill="currentColor" d="M310 480c-14 15-50 32-98 32-120 0-147-89-147-141V227H18c-6 0-10-4-10-10v-68c0-7 4-13 11-16 62-21 82-76 85-117 0-11 6-16 16-16h71c5 0 10 4 10 10v115h83c5 0 10 5 10 10v82c0 5-5 10-10 10h-84v133c0 34 24 54 68 36 5-2 9-3 13-2 3 1 6 3 7 8l22 64c2 5 3 10 0 14z"/></svg></a></li>
           {% endif %}
 
           {% if theme.bandcamp_url != blank %}
             <li><a href="{{ theme.bandcamp_url }}" title="Bandcamp"><svg class="bandcamp-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M349 406H0l163-300h349L349 406Z"/></svg></a></li> 
-          {% endif %}
-
-          {% if theme.linkedin_url != blank %}
-            <li><a href="{{ theme.linkedin_url }}" title="LinkedIn"><svg class="linkedin-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"/></svg></a></li>
           {% endif %}
         </ul>
       {% endif %}

--- a/source/maintenance.html
+++ b/source/maintenance.html
@@ -22,6 +22,7 @@
           or theme.youtube_url != blank
           or theme.spotify_url != blank
           or theme.linkedin_url != blank
+          or theme.twitch_url != blank
           or theme.tumblr_url != blank
           or theme.bandcamp_url != blank %}
         <ul class="social-links">
@@ -67,6 +68,10 @@
 
           {% if theme.linkedin_url != blank %}
             <li><a href="{{ theme.linkedin_url }}" title="LinkedIn"><svg class="linkedin-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"/></svg></a></li>
+          {% endif %}
+
+          {% if theme.twitch_url != blank %}
+            <li><a href="{{ theme.twitch_url }}" title="Twitch"><svg class="twitch-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M391.2 103.5H352.5v109.7h38.6zM285 103H246.4V212.8H285zM120.8 0 24.3 91.4V420.6H140.1V512l96.5-91.4h77.3L487.7 256V0zM449.1 237.8l-77.2 73.1H294.6l-67.6 64v-64H140.1V36.6H449.1z"/></svg></a></li>
           {% endif %}
 
           {% if theme.tumblr_url != blank %}

--- a/source/product.html
+++ b/source/product.html
@@ -58,7 +58,7 @@
         {% endif %}
         <button class="button add-to-cart-button" name="submit" type="submit" data-add-title="Add to Cart" data-sold-title="Sold out">Add to Cart</button>
         {{ store | instant_checkout_button: 'dark', '44px' }}
-
+        <div class="inventory-status-message" data-inventory-message></div>
         {% if product.has_option_groups %}
           <div class="reset-selection-button-container">
             <button class="button minimal-button reset-selection-button" title="Reset selection" type="reset">Reset selection</button>

--- a/source/settings.json
+++ b/source/settings.json
@@ -415,6 +415,7 @@
       "variable": "maintenance_message",
       "label": "Maintenance mode message",
       "type": "text",
+      "max_length": 2048,
       "description": "A message visitors see when your shop is in Maintenance Mode",
       "default": "We're working on our shop right now.<br /><br />Please check back soon."
     },

--- a/source/settings.json
+++ b/source/settings.json
@@ -676,6 +676,27 @@
       "description": "Show categories in the footer"
     },
     {
+      "variable": "footer_text",
+      "label": "Footer text",
+      "type": "text",
+      "max_length": 2048,
+      "description": "Show a custom message to your shop's footer"
+    },
+    {
+      "variable": "footer_text_position",
+      "label": "Footer text position",
+      "type": "select",
+      "options": [
+        ["Start of footer", "start"],
+        ["End of footer", "end"]
+      ],
+      "default": "end",
+      "description": "Choose where to show your footer message",
+      "requires": [
+        "footer_text present"
+      ]
+    },
+    {
       "variable": "instagram_url",
       "label": "Instagram URL",
       "type": "text",

--- a/source/settings.json
+++ b/source/settings.json
@@ -53,6 +53,7 @@
               "button_rollover_color": "#255B8A",
               "product_status_text_color_primary": "#E60000",
               "product_status_text_color_secondary": "#787878",
+              "inventory_status_text_color": "#E60000",
               "announcement_background_color": "#255B8A",
               "announcement_text_color": "#FFFFFF"
             }
@@ -79,6 +80,7 @@
               "button_rollover_color": "#AEAEAE",
               "product_status_text_color_primary": "#4E6EE8",
               "product_status_text_color_secondary": "#CCCCCC",
+              "inventory_status_text_color": "#4E6EE8",
               "announcement_background_color": "#494949",
               "announcement_text_color": "#F8F8F8"
             }
@@ -105,6 +107,7 @@
               "button_rollover_color": "#2A2A2C",
               "product_status_text_color_primary": "#E60000",
               "product_status_text_color_secondary": "#888888",
+              "inventory_status_text_color": "#E60000",
               "announcement_background_color": "#203BE1",
               "announcement_text_color": "#F8F8FA"
             }
@@ -136,6 +139,7 @@
               "button_rollover_color": "#7C3C17",
               "product_status_text_color_primary": "#A64300",
               "product_status_text_color_secondary": "#7F7F7F",
+              "inventory_status_text_color": "#A64300",
               "announcement_background_color": "#7C3C17",
               "announcement_text_color": "#F2EEE7"
             }
@@ -162,6 +166,7 @@
               "button_rollover_color": "#FFF5E5",
               "product_status_text_color_primary": "#FF8C00",
               "product_status_text_color_secondary": "#888888",
+              "inventory_status_text_color": "#FF8C00",
               "announcement_background_color": "#FF8C00",
               "announcement_text_color": "#332F2F"
             }
@@ -188,6 +193,7 @@
               "button_rollover_color": "#0F1B27",
               "product_status_text_color_primary": "#D08770",
               "product_status_text_color_secondary": "#7F7F7F",
+              "inventory_status_text_color": "#D08770",
               "announcement_background_color": "#D08770",
               "announcement_text_color": "#0F1B27"
             }
@@ -219,6 +225,7 @@
               "button_rollover_color": "#EBD300",
               "product_status_text_color_primary": "#FFA500",
               "product_status_text_color_secondary": "#7F7F7F",
+              "inventory_status_text_color": "#FFA500",
               "announcement_background_color": "#FFE500",
               "announcement_text_color": "#222222"
             }
@@ -245,6 +252,7 @@
               "button_rollover_color": "#13A6B6",
               "product_status_text_color_primary": "#18D1E6",
               "product_status_text_color_secondary": "#919191",
+              "inventory_status_text_color": "#18D1E6",
               "announcement_background_color": "#18D1E6",
               "announcement_text_color": "#000000"
             }
@@ -271,6 +279,7 @@
               "button_rollover_color": "#FF61BD",
               "product_status_text_color_primary": "#FF169E",
               "product_status_text_color_secondary": "#7F7F7F",
+              "inventory_status_text_color": "#FF169E",
               "announcement_background_color": "#FF169E",
               "announcement_text_color": "#FFFFFF"
             }
@@ -297,6 +306,7 @@
               "button_rollover_color": "#B0094F",
               "product_status_text_color_primary": "#FF1493",
               "product_status_text_color_secondary": "#C390F6",
+              "inventory_status_text_color": "#FF1493",
               "announcement_background_color": "#EE178B",
               "announcement_text_color": "#FFFFFF"
             }
@@ -394,6 +404,11 @@
       "default": "#787878"
     },
     {
+      "variable": "inventory_status_text_color",
+      "label": "Low Inventory messages",
+      "default": "#E15C2A"
+    },
+    {
       "variable": "announcement_background_color",
       "label": "Announcement background",
       "default": "#000000"
@@ -409,6 +424,7 @@
       "variable": "announcement_message_text",
       "label": "Announcement text",
       "type": "text",
+      "max_length": 500,
       "description": "Displays an announcement message on the top of every page"
     },
     {
@@ -668,6 +684,57 @@
       "default": false,
       "description": "Shows a product's inventory amounts (when using inventory tracking)",
       "requires": ["inventory"]
+    },
+    {
+      "variable": "show_low_inventory_messages",
+      "label": "Show product stock alerts",
+      "type": "boolean",
+      "default": true,
+      "description": "Show shoppers alerts on Product pages when it's running low on stock",
+      "requires": [
+        "inventory",
+        "show_inventory_bars eq false"
+      ]
+    },
+    {
+      "variable": "low_inventory_threshold",
+      "label": "Low stock alert",
+      "options": "1..100",
+      "type": "select",
+      "default": "10",
+      "description": "When stock drops below this number, shoppers will see low stock message. 'Almost sold out' message shows at half this amount",
+      "requires": [
+        "inventory",
+        "show_inventory_bars eq false",
+        "show_low_inventory_messages eq true"
+      ]
+    },
+    {
+      "variable": "low_inventory_message",
+      "label": "Low stock message",
+      "type": "text",
+      "max_length": 50,
+      "description": "Message shown when stock drops below your alert level",
+      "default": "Limited quantities available",
+      "requires": [
+        "inventory",
+        "show_inventory_bars eq false",
+        "show_low_inventory_messages eq true"
+      ]
+    },
+    {
+      "variable": "almost_sold_out_message",
+      "label": "Almost sold out message",
+      "type": "text",
+      "max_length": 50,
+      "description": "Message shown when stock drops below half your alert level",
+      "default": "Only a few left!",
+      "requires": [
+        "inventory",
+        "show_inventory_bars eq false",
+        "show_low_inventory_messages eq true",
+        "low_inventory_threshold gt 1"
+      ]
     },
     {
       "variable": "show_categories_in_footer",

--- a/source/settings.json
+++ b/source/settings.json
@@ -593,11 +593,13 @@
       "label": "Show related products",
       "type": "boolean",
       "default": true,
+      "description": "Displays related products on Product pages"
     },
     {
       "variable": "similar_products_header",
       "label": "Related products header",
       "type": "text",
+      "max_length": 75,
       "description": "Displays above related products on Products pages",
       "default": "You might also like",
       "requires": [

--- a/source/settings.json
+++ b/source/settings.json
@@ -457,7 +457,10 @@
         ["Fastest", 3000]
       ],
       "default": 4000,
-      "description": "Controls how quickly slides advance in the auto-playing slideshow"
+      "description": "Controls how quickly slides advance in the auto-playing slideshow",
+      "requires": [
+        "homepage_slideshow_autoplay eq true"
+      ]
     },
     {
       "variable": "featured_header",

--- a/source/settings.json
+++ b/source/settings.json
@@ -593,7 +593,42 @@
       "label": "Show related products",
       "type": "boolean",
       "default": true,
-      "description": "Displays related products on the Product page"
+    },
+    {
+      "variable": "similar_products_header",
+      "label": "Related products header",
+      "type": "text",
+      "description": "Displays above related products on Products pages",
+      "default": "You might also like",
+      "requires": [
+        "show_similar_products eq true"
+      ]
+    },
+    {
+      "variable": "similar_products",
+      "label": "Related products",
+      "type": "select",
+      "options": "1..8",
+      "default": 3,
+      "description": "The maximum number of related products to show on Product pages",
+      "requires": [
+        "show_similar_products eq true"
+      ]
+    },
+    {
+      "variable": "similar_products_order",
+      "label": "Related products order",
+      "type": "select",
+      "options": [
+        ["Top Selling", "sales"],
+        ["Newest", "newest"],
+        ["Regular", "regular"]
+      ],
+      "default": "sales",
+      "description": "The order of related products on the Product pages",
+      "requires": [
+        "show_similar_products eq true"
+      ]
     },
     {
       "variable": "show_search",

--- a/source/settings.json
+++ b/source/settings.json
@@ -574,7 +574,7 @@
         ["Stacked 2 column", "two-column"],
         ["Stacked full width", "stacked"]
       ],
-      "default": "stacked",
+      "default": "thumbnails",
       "description": "Sets the display of the Product page gallery"
     },
     {

--- a/source/settings.json
+++ b/source/settings.json
@@ -442,7 +442,7 @@
       "variable": "homepage_slideshow_autoplay",
       "label": "Auto-play homepage slideshow",
       "type": "boolean",
-      "default": false,
+      "default": true,
       "description": "Automatically advances slides in the homepage slideshow"
     },
     {

--- a/source/settings.json
+++ b/source/settings.json
@@ -630,12 +630,8 @@
       "variable": "similar_products_order",
       "label": "Related products order",
       "type": "select",
-      "options": [
-        ["Top Selling", "sales"],
-        ["Newest", "newest"],
-        ["Regular", "regular"]
-      ],
-      "default": "sales",
+      "options": "product_orders",
+      "default": "top-selling",
       "description": "The order of related products on the Product pages",
       "requires": [
         "show_similar_products eq true"
@@ -649,20 +645,12 @@
       "description": "Displays a search field in the footer"
     },
     {
-      "variable": "show_inventory_bars",
-      "label": "Show inventory bars",
-      "type": "boolean",
-      "default": false,
-      "description": "Shows a product's inventory amounts (when using inventory tracking)",
-      "requires": "inventory"
-    },
-    {
       "variable": "show_sold_out_product_options",
       "label": "Show sold out product variants",
       "type": "boolean",
       "default": true,
       "description": "Shows sold out product variants in the Product page dropdowns",
-      "requires": "inventory"
+      "requires": ["inventory"]
     },
     {
       "variable": "show_sold_out_product_prices",
@@ -670,7 +658,15 @@
       "type": "boolean",
       "default": true,
       "description": "Show the price of sold out products on product grids and product pages",
-      "requires": "inventory"
+      "requires": ["inventory"]
+    },
+    {
+      "variable": "show_inventory_bars",
+      "label": "Show inventory bars",
+      "type": "boolean",
+      "default": false,
+      "description": "Shows a product's inventory amounts (when using inventory tracking)",
+      "requires": ["inventory"]
     },
     {
       "variable": "instagram_url",

--- a/source/settings.json
+++ b/source/settings.json
@@ -681,6 +681,12 @@
       "description": "Ex: https://youtube.com/@BigCartelDotCom"
     },
     {
+      "variable": "spotify_url",
+      "label": "Spotify URL",
+      "type": "text",
+      "description": "Ex: https://open.spotify.com/artist/0gxy..."
+    },
+    {
       "variable": "linkedin_url",
       "label": "LinkedIn URL",
       "type": "text",

--- a/source/settings.json
+++ b/source/settings.json
@@ -669,6 +669,13 @@
       "requires": ["inventory"]
     },
     {
+      "variable": "show_categories_in_footer",
+      "label": "Show categories in footer",
+      "type": "boolean",
+      "default": true,
+      "description": "Show categories in the footer"
+    },
+    {
       "variable": "instagram_url",
       "label": "Instagram URL",
       "type": "text",

--- a/source/settings.json
+++ b/source/settings.json
@@ -463,13 +463,6 @@
       ]
     },
     {
-      "variable": "featured_header",
-      "label": "Featured products header",
-      "type": "text",
-      "description": "Displays above featured products on the Home page",
-      "default": "Featured"
-    },
-    {
       "variable": "featured_items",
       "label": "Featured products",
       "type": "select",
@@ -483,7 +476,20 @@
       "type": "select",
       "options": "product_orders",
       "default": "position",
-      "description": "The order of products on the Home page"
+      "description": "The order of products on the Home page",
+      "requires": [
+        "featured_items gt 0"
+      ]
+    },
+    {
+      "variable": "featured_header",
+      "label": "Featured products header",
+      "type": "text",
+      "description": "Displays above featured products on the Home page",
+      "default": "Featured",
+      "requires": [
+        "featured_items gt 0"
+      ]
     },
     {
       "variable": "max_products_per_row",

--- a/source/settings.json
+++ b/source/settings.json
@@ -61,141 +61,141 @@
           {
             "style_name": "Classic #2",
             "fonts": {
-              "primary_font": "DM Sans",
-              "secondary_font": "DM Sans"
+              "primary_font": "Enriqueta",
+              "secondary_font": "Karla"
             },
             "colors": {
-              "background_color": "#141415",
-              "secondary_background_color": "#141415",
-              "primary_text_color": "#F8F8F8",
-              "secondary_text_color": "#F8F8F8",
-              "link_text_color": "#F8F8F8",
-              "link_rollover_color": "#AEAEAE",
-              "shop_name_text_color": "#F8F8F8",
-              "header_text_color": "#F8F8F8",
-              "products_background_color": "#141415",
-              "border_color": "#494949",
-              "button_text_color": "#141415",
-              "button_background_color": "#F8F8F8",
-              "button_rollover_color": "#AEAEAE",
-              "product_status_text_color_primary": "#4E6EE8",
-              "product_status_text_color_secondary": "#CCCCCC",
-              "inventory_status_text_color": "#4E6EE8",
-              "announcement_background_color": "#494949",
-              "announcement_text_color": "#F8F8F8"
+              "background_color": "#2D3319",
+              "secondary_background_color": "#2D3319",
+              "primary_text_color": "#F4F1DE",
+              "secondary_text_color": "#D8D4BC",
+              "link_text_color": "#F4F1DE",
+              "link_rollover_color": "#E09F3E",
+              "shop_name_text_color": "#FFFFFF",
+              "header_text_color": "#F4F1DE",
+              "products_background_color": "#232810",
+              "border_color": "#3D4425",
+              "button_text_color": "#2D3319",
+              "button_background_color": "#E09F3E",
+              "button_rollover_color": "#C78A2F",
+              "product_status_text_color_primary": "#E09F3E",
+              "product_status_text_color_secondary": "#D8D4BC",
+              "inventory_status_text_color": "#E09F3E",
+              "announcement_background_color": "#3D4425",
+              "announcement_text_color": "#F4F1DE"
             }
           },
           {
             "style_name": "Classic #3",
             "fonts": {
-              "primary_font": "Poppins",
-              "secondary_font": "Poppins"
+              "primary_font": "Arvo",
+              "secondary_font": "Source Sans Pro"
             },
             "colors": {
-              "background_color": "#F8F8FA",
-              "secondary_background_color": "#F8F8FA",
-              "primary_text_color": "#2A2A2C",
-              "secondary_text_color": "#2A2A2C",
-              "link_text_color": "#2A2A2C",
-              "link_rollover_color": "#203BE1",
-              "shop_name_text_color": "#2A2A2C",
-              "header_text_color": "#2A2A2C",
-              "products_background_color": "#203BE1",
-              "border_color": "#E3E4EA",
+              "background_color": "#F8F9FA",
+              "secondary_background_color": "#EDF2F7",
+              "primary_text_color": "#1A365D",
+              "secondary_text_color": "#4A5568",
+              "link_text_color": "#1A365D",
+              "link_rollover_color": "#7B341E",
+              "shop_name_text_color": "#1A365D",
+              "header_text_color": "#1A365D",
+              "products_background_color": "#1A365D",
+              "border_color": "#E2E8F0",
               "button_text_color": "#FFFFFF",
-              "button_background_color": "#203BE1",
-              "button_rollover_color": "#2A2A2C",
-              "product_status_text_color_primary": "#E60000",
-              "product_status_text_color_secondary": "#888888",
-              "inventory_status_text_color": "#E60000",
-              "announcement_background_color": "#203BE1",
-              "announcement_text_color": "#F8F8FA"
+              "button_background_color": "#7B341E",
+              "button_rollover_color": "#652B1B",
+              "product_status_text_color_primary": "#7B341E",
+              "product_status_text_color_secondary": "#718096",
+              "inventory_status_text_color": "#7B341E",
+              "announcement_background_color": "#7B341E",
+              "announcement_text_color": "#F8F9FA"
             }
           }
         ]
       },
       {
-        "group_name": "Elegant",
+        "group_name": "Bold",
         "styles": [
           {
-            "style_name": "Elegant #1",
+            "style_name": "Bold #1",
             "fonts": {
-              "primary_font": "Spectral",
-              "secondary_font": "Cabin"
+              "primary_font": "BioRhyme",
+              "secondary_font": "DM Sans"
             },
             "colors": {
-              "background_color": "#F2EEE7",
-              "secondary_background_color": "#F2EEE7",
-              "primary_text_color": "#262522",
-              "secondary_text_color": "#262522",
-              "link_text_color": "#262522",
-              "link_rollover_color": "#7C3C17",
-              "shop_name_text_color": "#262522",
-              "header_text_color": "#262522",
-              "products_background_color": "#262522",
-              "border_color": "#C3C0B0",
-              "button_text_color": "#F5F4EE",
-              "button_background_color": "#262522",
-              "button_rollover_color": "#7C3C17",
-              "product_status_text_color_primary": "#A64300",
-              "product_status_text_color_secondary": "#7F7F7F",
-              "inventory_status_text_color": "#A64300",
-              "announcement_background_color": "#7C3C17",
-              "announcement_text_color": "#F2EEE7"
+              "background_color": "#7209B7",
+              "secondary_background_color": "#5F07A0",
+              "primary_text_color": "#FFFFFF",
+              "secondary_text_color": "#DFB8F5",
+              "link_text_color": "#FFFFFF",
+              "link_rollover_color": "#4CC9F0",
+              "shop_name_text_color": "#FFFFFF",
+              "header_text_color": "#FFFFFF",
+              "products_background_color": "#5F07A0",
+              "border_color": "#8A0AD6",
+              "button_text_color": "#7209B7",
+              "button_background_color": "#4CC9F0",
+              "button_rollover_color": "#22B9EB",
+              "product_status_text_color_primary": "#4CC9F0",
+              "product_status_text_color_secondary": "#DFB8F5",
+              "inventory_status_text_color": "#4CC9F0",
+              "announcement_background_color": "#4CC9F0",
+              "announcement_text_color": "#7209B7"
             }
           },
           {
-            "style_name": "Elegant #2",
+            "style_name": "Bold #2",
             "fonts": {
-              "primary_font": "Marcellus",
-              "secondary_font": "Inter"
+              "primary_font": "Titillium Web",
+              "secondary_font": "Work Sans"
             },
             "colors": {
-              "background_color": "#332F2F",
-              "secondary_background_color": "#332F2F",
-              "primary_text_color": "#FFF5E5",
-              "secondary_text_color": "#FFF5E5",
-              "link_text_color": "#FFF5E5",
-              "link_rollover_color": "#CAB696",
-              "shop_name_text_color": "#FFF5E5",
-              "header_text_color": "#FFF5E5",
-              "products_background_color": "#141415",
-              "border_color": "#605553",
-              "button_text_color": "#222121",
-              "button_background_color": "#CAB696",
-              "button_rollover_color": "#FFF5E5",
-              "product_status_text_color_primary": "#FF8C00",
-              "product_status_text_color_secondary": "#888888",
-              "inventory_status_text_color": "#FF8C00",
-              "announcement_background_color": "#FF8C00",
-              "announcement_text_color": "#332F2F"
+              "background_color": "#FF2E00",
+              "secondary_background_color": "#FF2E00",
+              "primary_text_color": "#FFFFFF",
+              "secondary_text_color": "#FFB8AA",
+              "link_text_color": "#FFFFFF",
+              "link_rollover_color": "#FFF500",
+              "shop_name_text_color": "#FFFFFF",
+              "header_text_color": "#FFFFFF",
+              "products_background_color": "#E62900",
+              "border_color": "#FF5233",
+              "button_text_color": "#FF2E00",
+              "button_background_color": "#FFF500",
+              "button_rollover_color": "#E6DC00",
+              "product_status_text_color_primary": "#FFF500",
+              "product_status_text_color_secondary": "#FFB8AA",
+              "inventory_status_text_color": "#FFF500",
+              "announcement_background_color": "#FFF500",
+              "announcement_text_color": "#FF2E00"
             }
           },
           {
-            "style_name": "Elegant #3",
+            "style_name": "Bold #3",
             "fonts": {
-              "primary_font": "Cormorant",
+              "primary_font": "Inknut Antiqua",
               "secondary_font": "Source Sans Pro"
             },
             "colors": {
-              "background_color": "#EBE7E7",
-              "secondary_background_color": "#EBE7E7",
-              "primary_text_color": "#0F1B27",
-              "secondary_text_color": "#0F1B27",
-              "link_text_color": "#0F1B27",
-              "link_rollover_color": "#8A5A5A",
-              "shop_name_text_color": "#0F1B27",
-              "header_text_color": "#0F1B27",
-              "products_background_color": "#0F1B27",
-              "border_color": "#DBD1D1",
-              "button_text_color": "#FFFFFF",
-              "button_background_color": "#D08770",
-              "button_rollover_color": "#0F1B27",
-              "product_status_text_color_primary": "#D08770",
-              "product_status_text_color_secondary": "#7F7F7F",
-              "inventory_status_text_color": "#D08770",
-              "announcement_background_color": "#D08770",
-              "announcement_text_color": "#0F1B27"
+              "background_color": "#000000",
+              "secondary_background_color": "#000000",
+              "primary_text_color": "#FFFFFF",
+              "secondary_text_color": "#A3A3A3",
+              "link_text_color": "#FFFFFF",
+              "link_rollover_color": "#00FF66",
+              "shop_name_text_color": "#FFFFFF",
+              "header_text_color": "#FFFFFF",
+              "products_background_color": "#141414",
+              "border_color": "#333333",
+              "button_text_color": "#000000",
+              "button_background_color": "#00FF66",
+              "button_rollover_color": "#00E65C",
+              "product_status_text_color_primary": "#00FF66",
+              "product_status_text_color_secondary": "#A3A3A3",
+              "inventory_status_text_color": "#00FF66",
+              "announcement_background_color": "#00FF66",
+              "announcement_text_color": "#000000"
             }
           }
         ]
@@ -206,108 +206,253 @@
           {
             "style_name": "Playful #1",
             "fonts": {
-              "primary_font": "Syne",
-              "secondary_font": "Syne"
+              "primary_font": "Quicksand",
+              "secondary_font": "Nunito Sans"
             },
             "colors": {
-              "background_color": "#F2F2F3",
-              "secondary_background_color": "#F2F2F3",
-              "primary_text_color": "#0000FF",
-              "secondary_text_color": "#0000FF",
-              "link_text_color": "#0000FF",
-              "link_rollover_color": "#000098",
-              "shop_name_text_color": "#0000FF",
-              "header_text_color": "#0000FF",
-              "products_background_color": "#FFE500",
-              "border_color": "#E0E1E7",
-              "button_text_color": "#0000FF",
-              "button_background_color": "#FFE500",
-              "button_rollover_color": "#EBD300",
-              "product_status_text_color_primary": "#FFA500",
-              "product_status_text_color_secondary": "#7F7F7F",
-              "inventory_status_text_color": "#FFA500",
-              "announcement_background_color": "#FFE500",
-              "announcement_text_color": "#222222"
+              "background_color": "#FF7549",
+              "secondary_background_color": "#FF7549",
+              "primary_text_color": "#FFFFFF",
+              "secondary_text_color": "#FFF6F4",
+              "link_text_color": "#FFFFFF",
+              "link_rollover_color": "#001B3D",
+              "shop_name_text_color": "#001B3D",
+              "header_text_color": "#FFFFFF",
+              "products_background_color": "#F26B3F",
+              "border_color": "#FF8F6B",
+              "button_text_color": "#FFFFFF",
+              "button_background_color": "#001B3D",
+              "button_rollover_color": "#002B61",
+              "product_status_text_color_primary": "#FFFFFF",
+              "product_status_text_color_secondary": "#FFD6CC",
+              "inventory_status_text_color": "#FFFFFF",
+              "announcement_background_color": "#001B3D",
+              "announcement_text_color": "#FF7549"
             }
           },
           {
             "style_name": "Playful #2",
             "fonts": {
-              "primary_font": "Yuji Mai",
-              "secondary_font": "Open Sans"
+              "primary_font": "Chewy",
+              "secondary_font": "Poppins"
             },
             "colors": {
-              "background_color": "#000000",
-              "secondary_background_color": "#000000",
-              "primary_text_color": "#DDDDDD",
-              "secondary_text_color": "#DDDDDD",
-              "link_text_color": "#DDDDDD",
-              "link_rollover_color": "#18D1E6",
-              "shop_name_text_color": "#18D1E6",
-              "header_text_color": "#18D1E6",
-              "products_background_color": "#FFFFFF",
-              "border_color": "#FFECF7",
-              "button_text_color": "#FFFFFF",
-              "button_background_color": "#18D1E6",
-              "button_rollover_color": "#13A6B6",
-              "product_status_text_color_primary": "#18D1E6",
-              "product_status_text_color_secondary": "#919191",
-              "inventory_status_text_color": "#18D1E6",
-              "announcement_background_color": "#18D1E6",
-              "announcement_text_color": "#000000"
+              "background_color": "#5D2AFF",
+              "secondary_background_color": "#4D1FE6",
+              "primary_text_color": "#FFFFFF",
+              "secondary_text_color": "#D1C2FF",
+              "link_text_color": "#FFFFFF",
+              "link_rollover_color": "#FFE81A",
+              "shop_name_text_color": "#FFE81A",
+              "header_text_color": "#FFFFFF",
+              "products_background_color": "#4D1FE6",
+              "border_color": "#7952FF",
+              "button_text_color": "#5D2AFF",
+              "button_background_color": "#FFE81A",
+              "button_rollover_color": "#FFE200",
+              "product_status_text_color_primary": "#FFE81A",
+              "product_status_text_color_secondary": "#D1C2FF",
+              "inventory_status_text_color": "#FFE81A",
+              "announcement_background_color": "#FFE81A",
+              "announcement_text_color": "#5D2AFF"
             }
           },
           {
             "style_name": "Playful #3",
             "fonts": {
-              "primary_font": "Quicksand",
-              "secondary_font": "Quicksand"
+              "primary_font": "Overlock",
+              "secondary_font": "DM Sans"
             },
             "colors": {
-              "background_color": "#FFECF7",
-              "secondary_background_color": "#FFECF7",
-              "primary_text_color": "#33246D",
-              "secondary_text_color": "#33246D",
-              "link_text_color": "#33246D",
-              "link_rollover_color": "#FF169E",
-              "shop_name_text_color": "#33246D",
-              "header_text_color": "#33246D",
-              "products_background_color": "#292929",
-              "border_color": "#FFECF7",
+              "background_color": "#00C2A8",
+              "secondary_background_color": "#00C2A8",
+              "primary_text_color": "#FFFFFF",
+              "secondary_text_color": "#B3FFF6",
+              "link_text_color": "#FFFFFF",
+              "link_rollover_color": "#2D1B69",
+              "shop_name_text_color": "#FFFFFF",
+              "header_text_color": "#FFFFFF",
+              "products_background_color": "#00A892",
+              "border_color": "#00DBBD",
               "button_text_color": "#FFFFFF",
-              "button_background_color": "#FF169E",
-              "button_rollover_color": "#FF61BD",
-              "product_status_text_color_primary": "#FF169E",
-              "product_status_text_color_secondary": "#7F7F7F",
-              "inventory_status_text_color": "#FF169E",
-              "announcement_background_color": "#FF169E",
+              "button_background_color": "#2D1B69",
+              "button_rollover_color": "#3D2589",
+              "product_status_text_color_primary": "#FFFFFF",
+              "product_status_text_color_secondary": "#B3FFF6",
+              "inventory_status_text_color": "#2D1B69",
+              "announcement_background_color": "#2D1B69",
+              "announcement_text_color": "#00C2A8"
+            }
+          }
+        ]
+      },
+      {
+        "group_name": "Earthy",
+        "styles": [
+          {
+            "style_name": "Earthy #1",
+            "fonts": {
+              "primary_font": "Hahmlet",
+              "secondary_font": "Source Sans Pro"
+            },
+            "colors": {
+              "background_color": "#F2E9E4",
+              "secondary_background_color": "#E8DDD5",
+              "primary_text_color": "#4A4236",
+              "secondary_text_color": "#7D6E5B",
+              "link_text_color": "#4A4236",
+              "link_rollover_color": "#C17817",
+              "shop_name_text_color": "#4A4236",
+              "header_text_color": "#4A4236",
+              "products_background_color": "#E8DDD5",
+              "border_color": "#D5C5B5",
+              "button_text_color": "#FFFFFF",
+              "button_background_color": "#C17817",
+              "button_rollover_color": "#A66614",
+              "product_status_text_color_primary": "#C17817",
+              "product_status_text_color_secondary": "#7D6E5B",
+              "inventory_status_text_color": "#C17817",
+              "announcement_background_color": "#C17817",
+              "announcement_text_color": "#F2E9E4"
+            }
+          },
+          {
+            "style_name": "Earthy #2",
+            "fonts": {
+              "primary_font": "Fauna One",
+              "secondary_font": "Work Sans"
+            },
+            "colors": {
+              "background_color": "#014235",
+              "secondary_background_color": "#014235",
+              "primary_text_color": "#F2F7F5",
+              "secondary_text_color": "#A7C4BC",
+              "link_text_color": "#F2F7F5",
+              "link_rollover_color": "#FFA62B",
+              "shop_name_text_color": "#F2F7F5",
+              "header_text_color": "#F2F7F5",
+              "products_background_color": "#013329",
+              "border_color": "#015C4B",
+              "button_text_color": "#014235",
+              "button_background_color": "#FFA62B",
+              "button_rollover_color": "#F59300",
+              "product_status_text_color_primary": "#FFA62B",
+              "product_status_text_color_secondary": "#A7C4BC",
+              "inventory_status_text_color": "#FFA62B",
+              "announcement_background_color": "#FFA62B",
+              "announcement_text_color": "#014235"
+            }
+          },
+          {
+            "style_name": "Earthy #3",
+            "fonts": {
+              "primary_font": "Fjord One",
+              "secondary_font": "Karla"
+            },
+            "colors": {
+              "background_color": "#FFFFFF",
+              "secondary_background_color": "#FFFFFF",
+              "primary_text_color": "#5C4B44",
+              "secondary_text_color": "#8C7B74",
+              "link_text_color": "#5C4B44",
+              "link_rollover_color": "#946B54",
+              "shop_name_text_color": "#5C4B44",
+              "header_text_color": "#5C4B44",
+              "products_background_color": "#FAF6F6",
+              "border_color": "#E8DADA",
+              "button_text_color": "#FFFFFF",
+              "button_background_color": "#946B54",
+              "button_rollover_color": "#7D5A46",
+              "product_status_text_color_primary": "#946B54",
+              "product_status_text_color_secondary": "#8C7B74",
+              "inventory_status_text_color": "#946B54",
+              "announcement_background_color": "#946B54",
+              "announcement_text_color": "#FFFFFF"
+            }
+          }
+        ]
+      },
+      {
+        "group_name": "Dreamy",
+        "styles": [
+          {
+            "style_name": "Dreamy #1",
+            "fonts": {
+              "primary_font": "Lora",
+              "secondary_font": "DM Sans"
+            },
+            "colors": {
+              "background_color": "#C8E7FF",
+              "secondary_background_color": "#B3DDFF",
+              "primary_text_color": "#2B5C8F",
+              "secondary_text_color": "#4F7CAD",
+              "link_text_color": "#2B5C8F",
+              "link_rollover_color": "#FF99B9",
+              "shop_name_text_color": "#2B5C8F",
+              "header_text_color": "#2B5C8F",
+              "products_background_color": "#B3DDFF",
+              "border_color": "#A3D3FF",
+              "button_text_color": "#FFFFFF",
+              "button_background_color": "#FF99B9",
+              "button_rollover_color": "#FF80A7",
+              "product_status_text_color_primary": "#FF99B9",
+              "product_status_text_color_secondary": "#4F7CAD",
+              "inventory_status_text_color": "#FF99B9",
+              "announcement_background_color": "#FF99B9",
               "announcement_text_color": "#FFFFFF"
             }
           },
           {
-            "style_name": "Playful #4",
+            "style_name": "Dreamy #2",
             "fonts": {
-              "primary_font": "Prompt",
-              "secondary_font": "Prompt"
+              "primary_font": "Spectral",
+              "secondary_font": "Quicksand"
             },
             "colors": {
-              "background_color": "#51168B",
-              "secondary_background_color": "#51168B",
-              "primary_text_color": "#FFFFFF",
-              "secondary_text_color": "#C390F6",
-              "link_text_color": "#FFFFFF",
-              "link_rollover_color": "#FFE462",
-              "shop_name_text_color": "#FFFFFF",
-              "header_text_color": "#FFFFFF",
-              "products_background_color": "#360665",
-              "border_color": "#C390F6",
+              "background_color": "#F3E6F0",
+              "secondary_background_color": "#EAD9E6",
+              "primary_text_color": "#805B7B",
+              "secondary_text_color": "#A68BA2",
+              "link_text_color": "#805B7B",
+              "link_rollover_color": "#B893B2",
+              "shop_name_text_color": "#805B7B",
+              "header_text_color": "#805B7B",
+              "products_background_color": "#EAD9E6",
+              "border_color": "#E0CCDC",
               "button_text_color": "#FFFFFF",
-              "button_background_color": "#EE178B",
-              "button_rollover_color": "#B0094F",
-              "product_status_text_color_primary": "#FF1493",
-              "product_status_text_color_secondary": "#C390F6",
-              "inventory_status_text_color": "#FF1493",
-              "announcement_background_color": "#EE178B",
+              "button_background_color": "#B893B2",
+              "button_rollover_color": "#9B7994",
+              "product_status_text_color_primary": "#B893B2",
+              "product_status_text_color_secondary": "#A68BA2",
+              "inventory_status_text_color": "#C77BA5",
+              "announcement_background_color": "#B893B2",
+              "announcement_text_color": "#FFFFFF"
+            }
+          },
+          {
+            "style_name": "Dreamy #3",
+            "fonts": {
+              "primary_font": "Cormorant",
+              "secondary_font": "Work Sans"
+            },
+            "colors": {
+              "background_color": "#F9F5FF",
+              "secondary_background_color": "#F0E8FF",
+              "primary_text_color": "#6B4D90",
+              "secondary_text_color": "#9B7EBF",
+              "link_text_color": "#6B4D90",
+              "link_rollover_color": "#4EA5D9",
+              "shop_name_text_color": "#6B4D90",
+              "header_text_color": "#6B4D90",
+              "products_background_color": "#F0E8FF",
+              "border_color": "#E6DAFF",
+              "button_text_color": "#FFFFFF",
+              "button_background_color": "#4EA5D9",
+              "button_rollover_color": "#3B8FBF",
+              "product_status_text_color_primary": "#4EA5D9",
+              "product_status_text_color_secondary": "#9B7EBF",
+              "inventory_status_text_color": "#4EA5D9",
+              "announcement_background_color": "#4EA5D9",
               "announcement_text_color": "#FFFFFF"
             }
           }

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Luna",
-  "version": "2.11.1",
+  "version": "2.12.0",
   "images": [
     {
       "variable": "header",

--- a/source/stylesheets/cart.sass
+++ b/source/stylesheets/cart.sass
@@ -3,9 +3,6 @@
     padding-left: 0
     padding-right: 0
 
-  .footer-nav
-    border: none
-
   .errors
     max-width: 960px
 

--- a/source/stylesheets/contact.sass
+++ b/source/stylesheets/contact.sass
@@ -41,8 +41,6 @@ button.send-message-button
   @media screen and (max-width: $break-small)
     max-width: 100%
 
-#contact_page .footer-nav
-  border-top: none
 
 #contact_page .errors
   max-width: 640px

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -17,6 +17,7 @@
   --products-background-color: #{'rgba(var(--products-background-color-rgb), .9)'}
 
   --border-color: #{"{{ theme.border_color }}"}
+  --border-color-secondary: color-mix(in srgb, var(--border-color) 50%, black)
 
   --button-text-color: #{"{{ theme.button_text_color }}"}
   --button-background-color: #{"{{ theme.button_background_color }}"}
@@ -373,8 +374,14 @@ button.button, a.button
 .custom .footer-nav
   border: none
 
+.footer-custom-content
+  color: var(--secondary-text-color)
+  padding: 20px 0
+
+footer
+  padding-top: 100px
+
 .footer-nav
-  border-top: 1px solid var(--border-color)
   +flexbox
   +flex-direction(column)
   +align-items(center)
@@ -398,9 +405,6 @@ button.button, a.button
         padding: 0
         width: 100%
 
-        li
-          border-bottom: 1px solid var(--border-color)
-
         a
           padding: $luna-base * 1.5 0
           text-align: center
@@ -411,6 +415,29 @@ button.button, a.button
 
       &:hover, &:focus
         color: var(--link-rollover-color)
+
+.wrapper
+  .footer-nav:nth-child(1)
+    position: relative
+    content: ""
+    top: 0
+    left: 50%
+    transform: translateX(-50%)
+    width: 1080px
+    max-width: 100%
+    border-top: 1px solid var(--border-color)
+
+  .footer-nav:nth-child(n+2)
+    position: relative
+    &::after
+      content: ""
+      position: absolute
+      top: 0
+      left: 50%
+      transform: translateX(-50%)
+      width: 100px
+      max-width: 100%
+      border-top: 1px solid var(--border-color-secondary)
 
 .social-links
   +flexbox

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -17,7 +17,6 @@
   --products-background-color: #{'rgba(var(--products-background-color-rgb), .9)'}
 
   --border-color: #{"{{ theme.border_color }}"}
-  --border-color-secondary: color-mix(in srgb, var(--border-color) 50%, black)
 
   --button-text-color: #{"{{ theme.button_text_color }}"}
   --button-background-color: #{"{{ theme.button_background_color }}"}
@@ -437,9 +436,9 @@ footer
       top: 0
       left: 50%
       transform: translateX(-50%)
-      width: 50px
+      width: 25px
       max-width: 100%
-      border-top: 1px solid var(--border-color-secondary)
+      border-top: 1px solid var(--border-color)
 
 .social-links
   +flexbox

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -30,6 +30,8 @@
   --product-status-text-color-primary: #{"{{ theme.product_status_text_color_primary }}"}
   --product-status-text-color-secondary: #{"{{ theme.product_status_text_color_secondary }}"}
 
+  --inventory-status-text-color: #{"{{ theme.inventory_status_text_color }}"}
+
   --announcement-background-color: #{'{{ theme.announcement_background_color }}'}
   --announcement-text-color: #{'{{ theme.announcement_text_color }}'}
 

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -435,7 +435,7 @@ footer
       top: 0
       left: 50%
       transform: translateX(-50%)
-      width: 100px
+      width: 50px
       max-width: 100%
       border-top: 1px solid var(--border-color-secondary)
 

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -137,10 +137,13 @@
     @media screen and (max-width: $break-small)
       width: #{"{% if theme.max_products_per_row_mobile == 2 %} 50% {% else %} 100% {% endif %}"}
 
+.related-products-container 
+  margin: 0 auto 60px auto
+
 .similar-products-header
   +flexbox
   +align-items(center)
-  padding: $luna-base * 3 0
+  padding: $luna-base * 3 0 0 0
   margin-top: $luna-base * 2
 
   @media screen and (max-width: $break-small)
@@ -149,7 +152,6 @@
 
   .similar-products-title
     font-size: $luna-font-base-px + 8
-    text-transform: capitalize
 
   .prev-next-products
     +flexbox

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -1,6 +1,3 @@
-#instant-checkout-button
-  margin-top: 12px
-
 #product_page
 
   .related-products-container.under_image + footer .footer-nav
@@ -238,3 +235,12 @@
     right: 0
     top: -16px
 
+#instant-checkout-button
+  margin-top: 12px
+
+.inventory-status-message
+  color: var(--inventory-status-text-color)
+  margin: 10px 0 auto
+  text-align: center
+  padding: 8px 0
+  font-weight: 500

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -140,6 +140,9 @@
 .related-products-container 
   margin: 0 auto 60px auto
 
+  @media screen and (max-width: $break-small)
+    margin-top: 40px
+
 .similar-products-header
   +flexbox
   +align-items(center)

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -2,8 +2,6 @@
   margin-top: 12px
 
 #product_page
-  .footer-nav
-    border: none
 
   .related-products-container.under_image + footer .footer-nav
     border-top: 1px solid var(--border-color)

--- a/source/stylesheets/products.sass
+++ b/source/stylesheets/products.sass
@@ -217,10 +217,6 @@ a.product-list-link
       text-decoration: underline
       text-underline-offset: 2px
 
-#products_page .footer-nav, #home_page .footer-nav
-  @media screen and (max-width: $break-small)
-    border-top: 0px
-
 #products_page .main .wrapper, #home_page .main .wrapper
   @media screen and (max-width: $break-small)
     .empty-products


### PR DESCRIPTION
- feat: redesigned related products to use collection off product drop. 
- feat: new settings to control related products: header, number of products and sort order
- feat: redesigned style presets into 5 new categories with new styles
- feat: limited quantity messaging on product pages, behavior controlled by new settings
- feat: custom footer text support
- chore: styling tweaks on footer
- chore: homepage slideshow now autoplays by default
- chore: remove "Back to site" from global nav
- chore: renamed setting `related_items` to `related_products`
- chore: change default desktop product page image to thumbnail