### PR TITLE
Luna v2.16.0

### DIFF
--- a/source/cart.html
+++ b/source/cart.html
@@ -56,16 +56,14 @@
               <a href="{{ cart.shareable_link }}" class="button footer minimal-button copy-cart-link" data-clipboard-text="{{ cart.shareable_link }}">Share this cart</a>
             {% endif %}
             {% if theme.show_bnpl_messaging and cart.items != blank %}
-              {% unless theme.features.opt_outs contains "theme_bnpl_messaging" %}
-                <div id="payment-processor-messaging">
-                  <div id="paypal-messaging-container" style="height: 0; overflow: hidden;">
-                    <div id="paypal-messaging-element"></div>
-                  </div>
-                  <div id="stripe-messaging-container" style="height: 0; overflow: hidden;">
-                    <div id="payment-method-messaging-element"></div>
-                  </div>
+              <div id="payment-processor-messaging">
+                <div id="paypal-messaging-container" style="height: 0; overflow: hidden;">
+                  <div id="paypal-messaging-element"></div>
                 </div>
-              {% endunless %}
+                <div id="stripe-messaging-container" style="height: 0; overflow: hidden;">
+                  <div id="payment-method-messaging-element"></div>
+                </div>
+              </div>
             {% endif %}
           </div>
         </div>

--- a/source/home.html
+++ b/source/home.html
@@ -66,7 +66,15 @@
                 <div class="product-list-thumb-info">
                   <div class="product-list-thumb-name">{{ product.name }}</div>
                   <div class="product-list-thumb-price">
-                    {% unless product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+                    {% assign hide_price = false %}
+                    {% if product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+                      {% assign hide_price = true %}
+                    {% endif -%}
+                    {% if product.status == 'coming-soon' and theme.show_coming_soon_product_prices == false %}
+                      {% assign hide_price = true %}
+                    {% endif %}
+
+                    {% unless hide_price %}
                       {% if product.variable_pricing %}
                         {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
                       {% else %}

--- a/source/layout.html
+++ b/source/layout.html
@@ -282,7 +282,9 @@
           {% if theme.footer_text != blank and theme.footer_text_position == "end" %}
             <div class="footer-custom-content">{{ theme.footer_text }} </div>
           {% endif %}
-          {{ powered_by_big_cartel }}
+          <div data-bc-hook="credit">
+            {{ powered_by_big_cartel }}
+          </div>
         </nav>
       </div>
     </footer>

--- a/source/product.html
+++ b/source/product.html
@@ -13,7 +13,15 @@
     {% if product_status != blank %}<div class="product-status {{ status_class }}">{{ product_status }}</div>{% endif %}
     <h1 class="product-title has-dash">{{ product.name }}</h1>
     <div class="product-price">
-      {% unless product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+      {% assign hide_price = false %}
+      {% if product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+        {% assign hide_price = true %}
+      {% endif -%}
+      {% if product.status == 'coming-soon' and theme.show_coming_soon_product_prices == false %}
+        {% assign hide_price = true %}
+      {% endif %}
+
+      {% unless hide_price %}
         {% if product.variable_pricing %}
           {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
         {% else %}

--- a/source/product.html
+++ b/source/product.html
@@ -68,16 +68,14 @@
     {% endif %}
 
     {% if product.status == "active" and theme.show_bnpl_messaging %}
-      {% unless theme.features.opt_outs contains "theme_bnpl_messaging" %}
-        <div id="payment-processor-messaging">
-          <div id="paypal-messaging-container" style="height: 0; overflow: hidden;">
-            <div id="paypal-messaging-element"></div>
-          </div>
-          <div id="stripe-messaging-container" style="height: 0; overflow: hidden;">
-            <div id="payment-method-messaging-element"></div>
-          </div>
+      <div id="payment-processor-messaging">
+        <div id="paypal-messaging-container" style="height: 0; overflow: hidden;">
+          <div id="paypal-messaging-element"></div>
         </div>
-      {% endunless %}
+        <div id="stripe-messaging-container" style="height: 0; overflow: hidden;">
+          <div id="payment-method-messaging-element"></div>
+        </div>
+      </div>
     {% endif %}
 
     {% if product.description != blank %}

--- a/source/products.html
+++ b/source/products.html
@@ -72,7 +72,15 @@
               <div class="product-list-thumb-info">
                 <div class="product-list-thumb-name">{{ product.name }}</div>
                 <div class="product-list-thumb-price">
-                  {% unless product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+                  {% assign hide_price = false %}
+                  {% if product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+                    {% assign hide_price = true %}
+                  {% endif -%}
+                  {% if product.status == 'coming-soon' and theme.show_coming_soon_product_prices == false %}
+                    {% assign hide_price = true %}
+                  {% endif %}
+
+                  {% unless hide_price %}
                     {% if product.variable_pricing %}
                       {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
                     {% else %}

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Luna",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "images": [
     {
       "variable": "header",

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Luna",
-  "version": "2.15.1",
+  "version": "2.16.0",
   "images": [
     {
       "variable": "header",

--- a/source/settings.json
+++ b/source/settings.json
@@ -715,6 +715,17 @@
       ]
     },
     {
+      "variable": "featured_header",
+      "label": "Featured products header",
+      "section": "homepage",
+      "type": "text",
+      "description": "Displays above featured products on the Home page",
+      "default": "Featured",
+      "requires": [
+        "featured_items gt 0"
+      ]
+    },
+    {
       "variable": "featured_items",
       "label": "Featured products",
       "section": "homepage",
@@ -731,17 +742,6 @@
       "options": "product_orders",
       "default": "position",
       "description": "The order of products on the Home page",
-      "requires": [
-        "featured_items gt 0"
-      ]
-    },
-    {
-      "variable": "featured_header",
-      "label": "Featured products header",
-      "section": "homepage",
-      "type": "text",
-      "description": "Displays above featured products on the Home page",
-      "default": "Featured",
       "requires": [
         "featured_items gt 0"
       ]

--- a/source/settings.json
+++ b/source/settings.json
@@ -925,7 +925,7 @@
       "default": true,
       "description": "Show payment options prior to checkout on product and cart pages. Requires paid plan.",
       "requires": [
-        "feature:theme_bnpl_messaging neq opted_out"
+        "feature:theme_bnpl_messaging eq visible"
       ],
       "plan_type": "paid"
     },

--- a/source/settings.json
+++ b/source/settings.json
@@ -830,6 +830,13 @@
       "requires": ["inventory"]
     },
     {
+      "variable": "show_coming_soon_product_prices",
+      "label": "Show prices for coming soon products",
+      "type": "boolean",
+      "default": true,
+      "description": "Show the price of coming soon products on product grids and product pages"
+    },
+    {
       "variable": "show_inventory_bars",
       "label": "Show inventory bars",
       "type": "boolean",

--- a/source/settings.json
+++ b/source/settings.json
@@ -569,31 +569,6 @@
   ],
   "options": [
     {
-      "variable": "announcement_message_text",
-      "label": "Announcement text",
-      "section": "messaging",
-      "type": "text",
-      "max_length": 500,
-      "description": "Displays an announcement message on the top of every page"
-    },
-    {
-      "variable": "maintenance_message",
-      "label": "Maintenance mode message",
-      "section": "messaging",
-      "type": "text",
-      "max_length": 2048,
-      "description": "A message visitors see when your shop is in Maintenance Mode",
-      "default": "We're working on our shop right now.<br /><br />Please check back soon."
-    },
-    {
-      "variable": "contact_text",
-      "label": "Contact page text",
-      "section": "messaging",
-      "type": "text",
-      "max_length": 1024,
-      "description": "Displays a message on your contact page"
-    },
-    {
       "variable": "header_image_height",
       "label": "Header image height",
       "section": "global_navigation",
@@ -614,6 +589,104 @@
       "options": "0..6",
       "default": 2,
       "description": "The number of custom page links to display in the main navigation."
+    },
+    {
+      "variable": "show_search",
+      "label": "Show search",
+      "section": "global_navigation",
+      "type": "boolean",
+      "default": true,
+      "description": "Displays a search field in the footer"
+    },
+    {
+      "variable": "show_overlay",
+      "label": "Product list info",
+      "section": "global_navigation",
+      "type": "select",
+      "options": [
+        ["On rollover", "rollover"],
+        ["Under image", "under_image"]
+      ],
+      "default": "under_image",
+      "description": "Shows a product's name & price on hover, or under the image"
+    },
+    {
+      "variable": "max_products_per_row",
+      "label": "Maximum products per row",
+      "section": "global_navigation",
+      "type": "select",
+      "options": "1..4",
+      "default": 3,
+      "description": "The number of products displayed per row"
+    },
+    {
+      "variable": "max_products_per_row_mobile",
+      "label": "Maximum products per row (mobile)",
+      "section": "global_navigation",
+      "type": "select",
+      "options": "1..2",
+      "default": 2,
+      "description": "The number of products displayed per row on small screens"
+    },
+    {
+      "variable": "products_per_page",
+      "label": "Products per page",
+      "section": "global_navigation",
+      "type": "select",
+      "options": "1..100",
+      "default": 36,
+      "description": "The number of products displayed per page"
+    },
+    {
+      "variable": "grid_image_style",
+      "label": "Product grid image style",
+      "section": "global_navigation",
+      "type": "select",
+      "options": [
+        ["Fit to square", "fit-to-square"],
+        ["Crop to square", "crop-to-square"]
+      ],
+      "default": "crop-to-square",
+      "description": "Sets the display of images in the product grid"
+    },
+    {
+      "variable": "show_categories_in_footer",
+      "label": "Show categories in footer",
+      "section": "global_navigation",
+      "type": "boolean",
+      "default": true,
+      "description": "Display product category links in your shop's footer"
+    },
+    {
+      "variable": "show_custom_pages_in_footer",
+      "label": "Show custom pages in footer",
+      "section": "global_navigation",
+      "type": "boolean",
+      "default": true,
+      "description": "Display links to your custom pages in your shop's footer"
+    },
+    {
+      "variable": "footer_text",
+      "label": "Footer text",
+      "section": "global_navigation",
+      "type": "text",
+      "max_length": 2048,
+      "description": "Show a custom message in your shop's footer"
+    },
+    {
+      "variable": "footer_text_position",
+      "label": "Footer text position",
+      "section": "global_navigation",
+      "type": "select",
+      "options": [
+        ["Start of footer", "start"],
+        ["End of footer", "end"]
+      ],
+      "default": "end",
+      "description": "Choose where to show your footer message",
+      "requires": [
+        "footer_text present"
+      ]
     },
     {
       "variable": "homepage_slideshow_autoplay",
@@ -674,75 +747,12 @@
       ]
     },
     {
-      "variable": "max_products_per_row",
-      "label": "Maximum products per row",
-      "section": "global_navigation",
-      "type": "select",
-      "options": "1..4",
-      "default": 3,
-      "description": "The number of products displayed per row"
-    },
-    {
-      "variable": "max_products_per_row_mobile",
-      "label": "Maximum products per row (mobile)",
-      "section": "global_navigation",
-      "type": "select",
-      "options": "1..2",
-      "default": 2,
-      "description": "The number of products displayed per row on small screens"
-    },
-    {
-      "variable": "products_per_page",
-      "label": "Products per page",
-      "section": "global_navigation",
-      "type": "select",
-      "options": "1..100",
-      "default": 36,
-      "description": "The number of products displayed per page"
-    },
-    {
-      "variable": "grid_image_style",
-      "label": "Product grid image style",
-      "section": "global_navigation",
-      "type": "select",
-      "options": [
-        ["Fit to square", "fit-to-square"],
-        ["Crop to square", "crop-to-square"]
-      ],
-      "default": "crop-to-square",
-      "description": "Sets the display of images in the product grid"
-    },
-    {
       "variable": "all_products_button_text",
       "label": "All products button text",
       "section": "homepage",
       "type": "text",
       "description": "Displays underneath featured products and links to your Products Page",
       "default": "All Products"
-    },
-    {
-      "variable": "show_overlay",
-      "label": "Product list info",
-      "section": "global_navigation",
-      "type": "select",
-      "options": [
-        ["On rollover", "rollover"],
-        ["Under image", "under_image"]
-      ],
-      "default": "under_image",
-      "description": "Shows a product's name & price on hover, or under the image"
-    },
-    {
-      "variable": "money_format",
-      "label": "Price display",
-      "section": "general",
-      "type": "select",
-      "options": [
-        ["Currency sign", "sign"],
-        ["Currency code with sign", "sign_and_code"]
-      ],
-      "default": "sign",
-      "description": "Sets the display of prices in your shop"
     },
     {
       "variable": "product_page_layout",
@@ -835,14 +845,6 @@
       ]
     },
     {
-      "variable": "show_search",
-      "label": "Show search",
-      "section": "global_navigation",
-      "type": "boolean",
-      "default": true,
-      "description": "Displays a search field in the footer"
-    },
-    {
       "variable": "show_sold_out_product_options",
       "label": "Show sold out product variants",
       "section": "product_page",
@@ -850,23 +852,6 @@
       "default": true,
       "description": "Shows sold out product variants in the Product page dropdowns",
       "requires": ["inventory"]
-    },
-    {
-      "variable": "show_sold_out_product_prices",
-      "label": "Show prices for sold out products",
-      "section": "general",
-      "type": "boolean",
-      "default": true,
-      "description": "Show the price of sold out products on product grids and product pages",
-      "requires": ["inventory"]
-    },
-    {
-      "variable": "show_coming_soon_product_prices",
-      "label": "Show prices for coming soon products",
-      "section": "general",
-      "type": "boolean",
-      "default": true,
-      "description": "Show the price of coming soon products on product grids and product pages"
     },
     {
       "variable": "show_inventory_bars",
@@ -933,45 +918,6 @@
       ]
     },
     {
-      "variable": "show_categories_in_footer",
-      "label": "Show categories in footer",
-      "section": "global_navigation",
-      "type": "boolean",
-      "default": true,
-      "description": "Display product category links in your shop's footer"
-    },
-    {
-      "variable": "show_custom_pages_in_footer",
-      "label": "Show custom pages in footer",
-      "section": "global_navigation",
-      "type": "boolean",
-      "default": true,
-      "description": "Display links to your custom pages in your shop's footer"
-    },
-    {
-      "variable": "footer_text",
-      "label": "Footer text",
-      "section": "global_navigation",
-      "type": "text",
-      "max_length": 2048,
-      "description": "Show a custom message in your shop's footer"
-    },
-    {
-      "variable": "footer_text_position",
-      "label": "Footer text position",
-      "section": "global_navigation",
-      "type": "select",
-      "options": [
-        ["Start of footer", "start"],
-        ["End of footer", "end"]
-      ],
-      "default": "end",
-      "description": "Choose where to show your footer message",
-      "requires": [
-        "footer_text present"
-      ]
-    },
-    {
       "variable": "show_bnpl_messaging",
       "label": "Buy Now, Pay Later Messaging",
       "section": "product_page",
@@ -981,6 +927,60 @@
       "requires": [
         "feature:theme_bnpl_messaging neq opted_out"
       ]
+    },
+    {
+      "variable": "money_format",
+      "label": "Price display",
+      "section": "general",
+      "type": "select",
+      "options": [
+        ["Currency sign", "sign"],
+        ["Currency code with sign", "sign_and_code"]
+      ],
+      "default": "sign",
+      "description": "Sets the display of prices in your shop"
+    },
+    {
+      "variable": "show_sold_out_product_prices",
+      "label": "Show prices for sold out products",
+      "section": "general",
+      "type": "boolean",
+      "default": true,
+      "description": "Show the price of sold out products on product grids and product pages",
+      "requires": ["inventory"]
+    },
+    {
+      "variable": "show_coming_soon_product_prices",
+      "label": "Show prices for coming soon products",
+      "section": "general",
+      "type": "boolean",
+      "default": true,
+      "description": "Show the price of coming soon products on product grids and product pages"
+    },
+    {
+      "variable": "announcement_message_text",
+      "label": "Announcement text",
+      "section": "messaging",
+      "type": "text",
+      "max_length": 500,
+      "description": "Displays an announcement message on the top of every page"
+    },
+    {
+      "variable": "maintenance_message",
+      "label": "Maintenance mode message",
+      "section": "messaging",
+      "type": "text",
+      "max_length": 2048,
+      "description": "A message visitors see when your shop is in Maintenance Mode",
+      "default": "We're working on our shop right now.<br /><br />Please check back soon."
+    },
+    {
+      "variable": "contact_text",
+      "label": "Contact page text",
+      "section": "messaging",
+      "type": "text",
+      "max_length": 1024,
+      "description": "Displays a message on your contact page"
     },
     {
       "variable": "instagram_url",

--- a/source/settings.json
+++ b/source/settings.json
@@ -5,11 +5,13 @@
     {
       "variable": "header",
       "label": "Header image",
+      "section": "global_navigation",
       "description": "Transparent background recommended"
     },
     {
       "variable": "background",
       "label": "Repeating background image",
+      "section": "general",
       "description": "200 x 200 image recommended"
     }
   ],
@@ -17,6 +19,7 @@
     {
       "variable": "slideshow",
       "label": "Slideshow",
+      "section": "homepage",
       "description": "900 x 500 images recommended"
     }
   ],
@@ -568,6 +571,7 @@
     {
       "variable": "announcement_message_text",
       "label": "Announcement text",
+      "section": "messaging",
       "type": "text",
       "max_length": 500,
       "description": "Displays an announcement message on the top of every page"
@@ -575,6 +579,7 @@
     {
       "variable": "maintenance_message",
       "label": "Maintenance mode message",
+      "section": "messaging",
       "type": "text",
       "max_length": 2048,
       "description": "A message visitors see when your shop is in Maintenance Mode",
@@ -583,6 +588,7 @@
     {
       "variable": "contact_text",
       "label": "Contact page text",
+      "section": "messaging",
       "type": "text",
       "max_length": 1024,
       "description": "Displays a message on your contact page"
@@ -590,6 +596,7 @@
     {
       "variable": "header_image_height",
       "label": "Header image height",
+      "section": "global_navigation",
       "type": "select",
       "options": [
         ["Small", "200"],
@@ -602,6 +609,7 @@
     {
       "variable": "nav_items",
       "label": "Navigation items",
+      "section": "global_navigation",
       "type": "select",
       "options": "0..6",
       "default": 2,
@@ -610,6 +618,7 @@
     {
       "variable": "homepage_slideshow_autoplay",
       "label": "Auto-play homepage slideshow",
+      "section": "homepage",
       "type": "boolean",
       "default": true,
       "description": "Automatically advances slides in the homepage slideshow"
@@ -617,6 +626,7 @@
     {
       "variable": "homepage_slideshow_speed",
       "label": "Slideshow speed",
+      "section": "homepage",
       "type": "select",
       "options": [
         ["Slowest", 6000],
@@ -634,6 +644,7 @@
     {
       "variable": "featured_items",
       "label": "Featured products",
+      "section": "homepage",
       "type": "select",
       "options": "0..100",
       "default": 12,
@@ -642,6 +653,7 @@
     {
       "variable": "featured_order",
       "label": "Featured products order",
+      "section": "homepage",
       "type": "select",
       "options": "product_orders",
       "default": "position",
@@ -653,6 +665,7 @@
     {
       "variable": "featured_header",
       "label": "Featured products header",
+      "section": "homepage",
       "type": "text",
       "description": "Displays above featured products on the Home page",
       "default": "Featured",
@@ -663,6 +676,7 @@
     {
       "variable": "max_products_per_row",
       "label": "Maximum products per row",
+      "section": "global_navigation",
       "type": "select",
       "options": "1..4",
       "default": 3,
@@ -671,6 +685,7 @@
     {
       "variable": "max_products_per_row_mobile",
       "label": "Maximum products per row (mobile)",
+      "section": "global_navigation",
       "type": "select",
       "options": "1..2",
       "default": 2,
@@ -679,6 +694,7 @@
     {
       "variable": "products_per_page",
       "label": "Products per page",
+      "section": "global_navigation",
       "type": "select",
       "options": "1..100",
       "default": 36,
@@ -687,6 +703,7 @@
     {
       "variable": "grid_image_style",
       "label": "Product grid image style",
+      "section": "global_navigation",
       "type": "select",
       "options": [
         ["Fit to square", "fit-to-square"],
@@ -698,6 +715,7 @@
     {
       "variable": "all_products_button_text",
       "label": "All products button text",
+      "section": "homepage",
       "type": "text",
       "description": "Displays underneath featured products and links to your Products Page",
       "default": "All Products"
@@ -705,6 +723,7 @@
     {
       "variable": "show_overlay",
       "label": "Product list info",
+      "section": "global_navigation",
       "type": "select",
       "options": [
         ["On rollover", "rollover"],
@@ -716,6 +735,7 @@
     {
       "variable": "money_format",
       "label": "Price display",
+      "section": "general",
       "type": "select",
       "options": [
         ["Currency sign", "sign"],
@@ -727,6 +747,7 @@
     {
       "variable": "product_page_layout",
       "label": "Product page layout",
+      "section": "product_page",
       "type": "select",
       "options": [
         ["Images on left", "images_left_details_right"],
@@ -738,6 +759,7 @@
     {
       "variable": "product_image_zoom",
       "label": "Enable product image zoom",
+      "section": "product_page",
       "type": "boolean",
       "default": true,
       "description": "Click to open a larger version of the Product page image"
@@ -745,6 +767,7 @@
     {
       "variable": "desktop_product_page_images",
       "label": "Desktop product page images",
+      "section": "product_page",
       "type": "select",
       "options": [
         ["Thumbnails", "thumbnails"],
@@ -758,6 +781,7 @@
     {
       "variable": "mobile_product_page_images",
       "label": "Mobile product page image carousel",
+      "section": "product_page",
       "type": "select",
       "options": [
         ["Show thumbnails", "show-thumbnails"],
@@ -769,6 +793,7 @@
     {
       "variable": "show_similar_products",
       "label": "Show related products",
+      "section": "product_page",
       "type": "boolean",
       "default": true,
       "description": "Displays related products on Product pages"
@@ -776,6 +801,7 @@
     {
       "variable": "similar_products_header",
       "label": "Related products header",
+      "section": "product_page",
       "type": "text",
       "max_length": 75,
       "description": "Displays above related products on Products pages",
@@ -787,6 +813,7 @@
     {
       "variable": "similar_products",
       "label": "Related products",
+      "section": "product_page",
       "type": "select",
       "options": "1..8",
       "default": 3,
@@ -798,6 +825,7 @@
     {
       "variable": "similar_products_order",
       "label": "Related products order",
+      "section": "product_page",
       "type": "select",
       "options": "product_orders",
       "default": "top-selling",
@@ -809,6 +837,7 @@
     {
       "variable": "show_search",
       "label": "Show search",
+      "section": "global_navigation",
       "type": "boolean",
       "default": true,
       "description": "Displays a search field in the footer"
@@ -816,6 +845,7 @@
     {
       "variable": "show_sold_out_product_options",
       "label": "Show sold out product variants",
+      "section": "product_page",
       "type": "boolean",
       "default": true,
       "description": "Shows sold out product variants in the Product page dropdowns",
@@ -824,6 +854,7 @@
     {
       "variable": "show_sold_out_product_prices",
       "label": "Show prices for sold out products",
+      "section": "general",
       "type": "boolean",
       "default": true,
       "description": "Show the price of sold out products on product grids and product pages",
@@ -832,6 +863,7 @@
     {
       "variable": "show_coming_soon_product_prices",
       "label": "Show prices for coming soon products",
+      "section": "general",
       "type": "boolean",
       "default": true,
       "description": "Show the price of coming soon products on product grids and product pages"
@@ -839,6 +871,7 @@
     {
       "variable": "show_inventory_bars",
       "label": "Show inventory bars",
+      "section": "product_page",
       "type": "boolean",
       "default": false,
       "description": "Shows a product's inventory amounts (when using inventory tracking)",
@@ -847,6 +880,7 @@
     {
       "variable": "show_low_inventory_messages",
       "label": "Show product stock alerts",
+      "section": "product_page",
       "type": "boolean",
       "default": true,
       "description": "Show shoppers alerts on Product pages when it's running low on stock",
@@ -858,6 +892,7 @@
     {
       "variable": "low_inventory_threshold",
       "label": "Low stock alert",
+      "section": "product_page",
       "options": "1..100",
       "type": "select",
       "default": "10",
@@ -871,6 +906,7 @@
     {
       "variable": "low_inventory_message",
       "label": "Low stock message",
+      "section": "product_page",
       "type": "text",
       "max_length": 50,
       "description": "Message shown when stock drops below your alert level",
@@ -884,6 +920,7 @@
     {
       "variable": "almost_sold_out_message",
       "label": "Almost sold out message",
+      "section": "product_page",
       "type": "text",
       "max_length": 50,
       "description": "Message shown when stock drops below half your alert level",
@@ -898,6 +935,7 @@
     {
       "variable": "show_categories_in_footer",
       "label": "Show categories in footer",
+      "section": "global_navigation",
       "type": "boolean",
       "default": true,
       "description": "Display product category links in your shop's footer"
@@ -905,6 +943,7 @@
     {
       "variable": "show_custom_pages_in_footer",
       "label": "Show custom pages in footer",
+      "section": "global_navigation",
       "type": "boolean",
       "default": true,
       "description": "Display links to your custom pages in your shop's footer"
@@ -912,6 +951,7 @@
     {
       "variable": "footer_text",
       "label": "Footer text",
+      "section": "global_navigation",
       "type": "text",
       "max_length": 2048,
       "description": "Show a custom message in your shop's footer"
@@ -919,6 +959,7 @@
     {
       "variable": "footer_text_position",
       "label": "Footer text position",
+      "section": "global_navigation",
       "type": "select",
       "options": [
         ["Start of footer", "start"],
@@ -933,6 +974,7 @@
     {
       "variable": "show_bnpl_messaging",
       "label": "Buy Now, Pay Later Messaging",
+      "section": "product_page",
       "type": "boolean",
       "default": true,
       "description": "Show payment options prior to checkout on product and cart pages. Requires paid plan.",

--- a/source/settings.json
+++ b/source/settings.json
@@ -928,7 +928,10 @@
       "label": "Buy Now, Pay Later Messaging",
       "type": "boolean",
       "default": true,
-      "description": "Show payment options prior to checkout on product and cart pages. Requires paid plan."
+      "description": "Show payment options prior to checkout on product and cart pages. Requires paid plan.",
+      "requires": [
+        "feature:theme_bnpl_messaging neq opted_out"
+      ]
     },
     {
       "variable": "instagram_url",

--- a/source/settings.json
+++ b/source/settings.json
@@ -926,7 +926,8 @@
       "description": "Show payment options prior to checkout on product and cart pages. Requires paid plan.",
       "requires": [
         "feature:theme_bnpl_messaging neq opted_out"
-      ]
+      ],
+      "plan_type": "paid"
     },
     {
       "variable": "money_format",

--- a/source/settings.json
+++ b/source/settings.json
@@ -985,78 +985,91 @@
     {
       "variable": "instagram_url",
       "label": "Instagram URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://instagram.com/bigcartel"
     },
     {
       "variable": "tiktok_url",
       "label": "TikTok URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://tiktok.com/@bigcartelofficial"
     },
     {
       "variable": "bluesky_url",
       "label": "Bluesky URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://bsky.app/profile/bigcartel.com"
     },
     {
       "variable": "threads_url",
       "label": "Threads URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://threads.net/@bigcartel"
     },
     {
       "variable": "twitter_url",
       "label": "X URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://x.com/bigcartel"
     },
     {
       "variable": "facebook_url",
       "label": "Facebook URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://facebook.com/bigcartel"
     },
     {
       "variable": "snapchat_url",
       "label": "Snapchat URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://snapchat.com/add/bigcartel"
     },
     {
       "variable": "pinterest_url",
       "label": "Pinterest URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://pinterest.com/big_cartel"
     },
     {
       "variable": "youtube_url",
       "label": "YouTube URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://youtube.com/@BigCartelDotCom"
     },
     {
       "variable": "spotify_url",
       "label": "Spotify URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://open.spotify.com/artist/0gxy..."
     },
     {
       "variable": "linkedin_url",
       "label": "LinkedIn URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://linkedin.com/in/bigcartel"
     },
     {
       "variable": "tumblr_url",
       "label": "Tumblr URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://bigcartel.tumblr.com"
     },
     {
       "variable": "bandcamp_url",
       "label": "Bandcamp URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://bigcartel.bandcamp.com"
     }

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -423,6 +423,7 @@ footer
 
     a
       display: block
+      color: var(--secondary-text-color)
       padding: $luna-base $luna-base * 2
 
       &:hover, &:focus


### PR DESCRIPTION
- feat: setting to hide coming soon products
- fix: footer links use secondary text color for consistency with rest of footer
- chore: remove unnecessary bnpl feature flag check 
- chore: bnpl messaging setting respects feature flag
- chore: add `data-bc-hook` for credit
- chore: define section values for theme settings
- chore: add `section` prop to social settings
- chore: reorder settings based on section prop
- chore: reorder featured header setting
- chore: add `plan_type` prop to bnpl setting for future use
- chore: use new feature flag format for visibility
