### PR TITLE
Luna 2.20.2

### DIFF
--- a/source/home.html
+++ b/source/home.html
@@ -146,7 +146,7 @@
 
   {% if categories_with_products != blank %}
     {% assign category_collages_enabled = false %}
-    {% if theme.features.has_theme_category_collages %}
+    {% if theme.features.has_theme_category_collages and theme.home_page_categories_image_style != 'single' %}
       {% assign category_collages_enabled = true %}
     {% endif %}
 

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Luna",
-  "version": "2.20.1",
+  "version": "2.20.2",
   "images": [
     {
       "variable": "header",
@@ -911,7 +911,8 @@
       "description": "Style of images shown for each category",
       "requires": [
         "feature:theme_category_collages eq visible",
-        "featured_categories gt 0"
+        "featured_categories gt 0",
+        "grid_image_style eq crop-to-square"
       ]
     },
     {
@@ -922,7 +923,8 @@
       "default": false,
       "description": "Display the number of products in each category",
       "requires": [
-        "featured_categories gt 0"
+        "featured_categories gt 0",
+        "grid_image_style eq crop-to-square"
       ]
     },
     {


### PR DESCRIPTION
fix: skip category collages if grid image style is fit-to-square and single image style