### PR TITLE
Luna v2.21.4

### DIFF
--- a/source/contact.html
+++ b/source/contact.html
@@ -45,7 +45,7 @@
         </div>
       </div>
       <div class="contact-form-block contact-send">
-        <button class="send-message-button button" type="submit" name="submit">{{ t['contact.send_button'] }}</button>
+        <button id="contact_button" class="send-message-button button" type="submit">{{ t['contact.send_button'] }}</button>
       </div>
       <div class="contact-form-block contact-recaptcha">
         <div class="recaptcha-note">

--- a/source/javascripts/functions.js
+++ b/source/javascripts/functions.js
@@ -1,3 +1,41 @@
+/**
+ * Theme debug mode
+ *
+ * Enable: sessionStorage.setItem('themeDebug', 'true')
+ * Disable: sessionStorage.removeItem('themeDebug')
+ *
+ * Enables detailed console logging for BNPL, polling, and other theme operations.
+ */
+window.bigcartel = window.bigcartel || {};
+window.bigcartel.theme = window.bigcartel.theme || {};
+window.bigcartel.theme.DEBUG = (function() {
+  try {
+    return sessionStorage.getItem('themeDebug') === 'true';
+  } catch (e) {
+    return false;
+  }
+})();
+
+/**
+ * Debug logging utility (global)
+ * Available globally throughout the theme. Only logs when theme debug mode is enabled.
+ *
+ * @param {string} category - Log category (e.g., 'BNPL', 'Polling', 'Cart')
+ * @param {...*} args - Arguments to log (supports multiple arguments like console.log)
+ *
+ * @example
+ * debugLog('BNPL', 'Skipping re-render - price unchanged ($' + finalPrice + ')');
+ * debugLog('Polling', 'Check #' + attemptCount + ' at ' + elapsed + 'ms');
+ */
+function debugLog(category) {
+  if (window.bigcartel && window.bigcartel.theme && window.bigcartel.theme.DEBUG) {
+    var args = Array.prototype.slice.call(arguments, 1);
+    args.unshift('[' + category + ']');
+    if (typeof console !== 'undefined' && console.log) {
+      console.log.apply(console, args);
+    }
+  }
+}
 
 function camelCaseToDash(string) {
   return string.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();

--- a/source/javascripts/product-payment-messaging.js
+++ b/source/javascripts/product-payment-messaging.js
@@ -66,7 +66,8 @@ const PAYMENT_CONFIG = {
   DEFAULT_ALIGNMENT: 'left',
   PARENT_CONTAINER: {
     containerId: 'payment-processor-messaging',
-    defaultDisplayMode: 'block'
+    defaultDisplayMode: 'block',
+    heightCaptureDelay: 500 // Wait for SDK iframes to finish rendering and layout
   }
 };
 
@@ -77,6 +78,7 @@ const PAYMENT_CONFIG = {
  * - Caching last rendered price (skips unnecessary re-renders)
  * - Debouncing rapid updates (prevents flicker)
  * - Tracking viewport width (resets heights on significant resize)
+ * - Tracking last parent container height (prevents layout shift on browser back)
  */
 let maxPaypalHeight = 0;
 let maxStripeHeight = 0;
@@ -84,6 +86,67 @@ let lastRenderedPrice = null;
 let updateTimeout = null;
 let lastViewportWidth = window.innerWidth;
 let resizeTimeout = null;
+
+/**
+ * Navigation type detection
+ * Detects if current page load is from back/forward navigation.
+ *
+ * Critical for layout shift prevention: browsers restore cached DOM on back/forward
+ * but third-party SDK iframes (Stripe, PayPal) don't restore their rendered content.
+ * This creates a temporary collapse until SDKs re-render, causing layout shift.
+ *
+ * By detecting back/forward navigation, we can pre-reserve space using the cached
+ * height from before navigation, eliminating the layout shift.
+ *
+ * Note: This flag is set once at page load and remains constant for the page lifetime.
+ * It is NOT reset after renders - see comment at end of renderBnplMessaging() for details.
+ */
+var isBackForwardNavigation = false;
+try {
+  var navEntry = performance.getEntriesByType('navigation')[0];
+  isBackForwardNavigation = !!(navEntry && navEntry.type === 'back_forward');
+} catch (e) {
+  // Performance API not available or failed
+  isBackForwardNavigation = false;
+}
+
+/**
+ * Retrieve last parent container height from sessionStorage for layout shift prevention.
+ *
+ * Why sessionStorage?
+ * - Persists across back/forward navigation within the same tab
+ * - Automatically cleared when tab is closed (no stale data across sessions)
+ * - Provides the exact height from before navigation
+ *
+ * Why page-specific keys?
+ * - Product and cart pages may have different messaging layouts/heights
+ * - Prevents cart page heights from overwriting product page heights
+ *
+ * Lifecycle:
+ * - Saved after each successful render (see heightCaptureDelay timeout)
+ * - Retrieved on back/forward navigation (below)
+ * - Cleared on fresh navigations to prevent stale data from different products
+ */
+var lastParentContainerHeight = 0;
+var currentPageType = document.body.getAttribute('data-bc-page-type') || 'unknown';
+try {
+  if (isBackForwardNavigation && currentPageType !== 'unknown') {
+    // On back/forward, use stored height from previous render of this page type
+    var storageKey = 'bnplParentHeight_' + currentPageType;
+    var stored = sessionStorage.getItem(storageKey);
+    if (stored) {
+      lastParentContainerHeight = parseInt(stored, 10) || 0;
+    }
+  } else if (currentPageType !== 'unknown') {
+    // On fresh navigation (navigate, reload), clear stale height for this page type
+    var storageKey = 'bnplParentHeight_' + currentPageType;
+    sessionStorage.removeItem(storageKey);
+    lastParentContainerHeight = 0;
+  }
+} catch (e) {
+  // sessionStorage not available
+  lastParentContainerHeight = 0;
+}
 
 /**
  * Helper functions
@@ -304,7 +367,7 @@ async function showBnplMessaging(price = null, options = {}) {
   // Validate price early
   const finalPrice = validatePrice(price);
   if (!finalPrice) {
-    console.info('[BNPL] Invalid price:', price);
+    console.error('[BNPL] Invalid price:', price);
     return;
   }
 
@@ -321,20 +384,26 @@ async function showBnplMessaging(price = null, options = {}) {
     parentContainer.style.left === 'auto' &&
     parentContainer.style.top === 'auto';
 
-  // Price caching: Skip re-render if price unchanged and messaging already visible
-  // unless forceRender is explicitly requested (e.g., for responsive alignment changes)
-  if (lastRenderedPrice === finalPrice && isParentVisible && !options.forceRender) {
+  // Price caching: Skip re-render if price unchanged and messaging already visible,
+  // unless forceRender is explicitly requested (e.g., for responsive alignment changes).
+  //
+  // Exception: Always re-render on back/forward navigation even if price matches,
+  // because browser restores DOM but not SDK iframe content, requiring fresh SDK render.
+  if (lastRenderedPrice === finalPrice && isParentVisible && !options.forceRender && !isBackForwardNavigation) {
+    debugLog('BNPL', 'Skipping re-render - price unchanged ($' + finalPrice + ') and already visible');
     return; // Same price, already showing - skip re-render
   }
 
   // Debouncing: For updates, delay to prevent rapid sequential re-renders
   if (isParentVisible) {
+    debugLog('BNPL', 'Debouncing update for price $' + finalPrice + ' (100ms delay)');
     clearTimeout(updateTimeout);
     updateTimeout = setTimeout(() => {
       renderBnplMessaging(finalPrice, options);
     }, 100);
   } else {
     // No debounce for initial page load
+    debugLog('BNPL', 'Initial render for price $' + finalPrice);
     renderBnplMessaging(finalPrice, options);
   }
 }
@@ -361,6 +430,18 @@ async function renderBnplMessaging(price, options = {}) {
 
   if (!parentContainer || !stripeContainer || !paypalContainer) {
     return;
+  }
+
+  // On back/forward navigation, reserve space immediately to prevent layout shift.
+  // Browsers restore the DOM but not SDK-rendered iframe content, causing the container
+  // to collapse momentarily while SDKs re-render. Pre-allocating the last known height
+  // prevents the page from shifting during this re-render period.
+  debugLog('BNPL', 'isBackForwardNavigation:', isBackForwardNavigation, 'lastParentContainerHeight:', lastParentContainerHeight);
+  if (isBackForwardNavigation && lastParentContainerHeight > 0) {
+    parentContainer.style.minHeight = `${lastParentContainerHeight}px`;
+    debugLog('BNPL', 'Reserved', lastParentContainerHeight, 'px for back/forward navigation');
+  } else if (isBackForwardNavigation) {
+    debugLog('BNPL', 'Cannot reserve space - no previous height captured');
   }
 
   const finalPrice = price; // Already validated by wrapper
@@ -417,12 +498,26 @@ async function renderBnplMessaging(price, options = {}) {
   }
 
   // Keep parent container out of the flow initially to prevent layout shifts
-  if (!isUpdate) {
+  // EXCEPT on back/forward with reserved height - keep it in flow so minHeight reserves space
+  const hasReservedHeight = isBackForwardNavigation && lastParentContainerHeight > 0;
+  if (!isUpdate && !hasReservedHeight) {
     // Keep parent container available but not affecting layout
     parentContainer.style.position = 'absolute';
     parentContainer.style.left = '-9999px';
     parentContainer.style.top = '-9999px';
-    
+
+    // Initialize inner containers
+    stripeContainer.style.height = '0';
+    stripeContainer.style.overflow = 'hidden';
+    paypalContainer.style.height = '0';
+    paypalContainer.style.overflow = 'hidden';
+  } else if (hasReservedHeight) {
+    // On back/forward with reserved height, keep container in layout flow
+    // so minHeight actually reserves space and prevents layout shift
+    parentContainer.style.position = 'static';
+    parentContainer.style.left = 'auto';
+    parentContainer.style.top = 'auto';
+
     // Initialize inner containers
     stripeContainer.style.height = '0';
     stripeContainer.style.overflow = 'hidden';
@@ -434,27 +529,39 @@ async function renderBnplMessaging(price, options = {}) {
   let paypalVisible = false;
   let stripeVisible = false;
 
+  debugLog('BNPL', 'Render starting - isBackForward:', isBackForwardNavigation, 'isStripeVisible:', isStripeVisible, 'isPaypalVisible:', isPaypalVisible);
+
   try {
-    // Process PayPal messaging
-    paypalVisible = await showPaypalMessaging(
-      finalPrice, 
-      colors, 
-      paypalContainer, 
-      isPaypalVisible, 
-      alignment, 
-      pageType
-    );
-    
-    // Process Stripe messaging with the provided alignment
-    if (isStripeVisible) {
-      // For updates, completely remount the Stripe element to preserve alignment
-      stripeVisible = await updateStripeMessaging(finalPrice, colors, stripeContainer, alignment);
+    // Determine Stripe rendering function before starting parallel execution.
+    // For updates and back/forward navigation, use direct DOM remount without temp container.
+    // On back/forward, browser may have restored cached DOM but SDKs don't restore iframe content,
+    // so we need to force a fresh render. For updates, the container is already visible so we can
+    // skip the detection phase and directly update.
+    let stripeRenderFn;
+    if (isStripeVisible || isBackForwardNavigation) {
+      debugLog('BNPL', 'Will call updateStripeMessaging (back/forward or visible)');
+      stripeRenderFn = () => updateStripeMessaging(finalPrice, colors, stripeContainer, alignment);
     } else {
-      // For initial detection, use fixed positioning technique
-      stripeVisible = await detectStripeWithExistingContainer(finalPrice, colors, stripeContainer, alignment);
+      // For initial detection, use off-screen temp container to avoid layout shift.
+      // This allows us to test if Stripe will show BNPL content without affecting page layout.
+      debugLog('BNPL', 'Will call detectStripeWithExistingContainer (initial detection)');
+      stripeRenderFn = () => detectStripeWithExistingContainer(finalPrice, colors, stripeContainer, alignment);
     }
+
+    // Process PayPal and Stripe in parallel to minimize total wait time.
+    // Each SDK has 2s render timeout, so parallel execution saves ~2s compared to sequential.
+    const [paypalResult, stripeResult] = await Promise.all([
+      showPaypalMessaging(finalPrice, colors, paypalContainer, isPaypalVisible, alignment, pageType),
+      stripeRenderFn()
+    ]);
+
+    paypalVisible = paypalResult;
+    stripeVisible = stripeResult;
+
+    debugLog('BNPL', 'PayPal result:', paypalVisible);
+    debugLog('BNPL', 'Stripe result:', stripeVisible);
   } catch (error) {
-    console.error('Error processing messaging:', error);
+    console.error('[BNPL Render] Error processing messaging:', error);
     // Continue with default values (false) if there's an error
   }
   
@@ -491,9 +598,48 @@ async function renderBnplMessaging(price, options = {}) {
 
     // Update cache after successful render
     lastRenderedPrice = finalPrice;
+
+    // Capture parent container height for layout shift prevention on browser back.
+    //
+    // Timing consideration: We wait after container becomes visible because:
+    // 1. SDKs (Stripe/PayPal) inject iframes asynchronously
+    // 2. Iframes may continue growing/laying out after initial render
+    // 3. We already waited 2s for SDK render, but final layout may not be stable
+    // 4. Capturing too early would cache an incomplete height, defeating the purpose
+    //
+    // The delay ensures we capture the final, stable height for accurate
+    // space reservation on future back/forward navigation.
+    setTimeout(function() {
+      lastParentContainerHeight = parentContainer.offsetHeight;
+      try {
+        if (currentPageType !== 'unknown') {
+          var storageKey = 'bnplParentHeight_' + currentPageType;
+          sessionStorage.setItem(storageKey, lastParentContainerHeight.toString());
+          debugLog('BNPL', 'Saved height', lastParentContainerHeight, 'px to', storageKey);
+        }
+      } catch (e) {
+        // sessionStorage not available, skip
+      }
+    }, PAYMENT_CONFIG.PARENT_CONTAINER.heightCaptureDelay);
   } else {
     parentContainer.style.display = 'none';
   }
+
+  // Note: We do NOT reset isBackForwardNavigation flag here.
+  //
+  // The flag is set once at page load based on navigation type, and should remain
+  // constant for the lifetime of the page. Resetting it after first render would
+  // break subsequent renders on the same page (e.g., option changes) because:
+  //
+  // 1. The browser's navigation type doesn't change mid-page
+  // 2. If we're on a back/forward page load, ALL renders should treat it as such
+  // 3. Resetting would incorrectly classify subsequent renders as normal page loads
+  //
+  // The original reset logic was attempting to prevent "subsequent price changes from
+  // using back/forward logic", but this was solving the wrong problem. The real issue
+  // was that we shouldn't be using the back/forward flag for detecting whether to
+  // re-render (which is what the price caching logic does). That's now properly
+  // handled by the separate lastRenderedPrice check in showBnplMessaging().
 }
 
 /**
@@ -510,14 +656,28 @@ async function detectStripeWithExistingContainer(price, { backgroundColor }, con
   const element = container.querySelector(`#${elementId}`);
   const { bigcartel } = window;
 
-  if (!element || 
-    typeof Stripe !== 'function' || 
+  if (!element ||
+    typeof Stripe !== 'function' ||
     !bigcartel?.checkout?.stripe_publishable_key ||
     !bigcartel?.account) {
     return false;
   }
 
-  try {        
+  try {
+    // Check if content already exists (e.g., from browser back/forward cache)
+    // This prevents unnecessary temp container detection when Stripe is already rendered
+    const existingIframe = element.querySelector('iframe');
+    if (existingIframe) {
+      const existingHeight = existingIframe.offsetHeight;
+      if (existingHeight >= PAYMENT_CONFIG.SUPPORTED_PROCESSORS.stripe.heightThresholds.minVisibleHeight) {
+        debugLog('BNPL', 'Stripe content already present (height: ' + existingHeight + 'px), skipping detection');
+        // Make container visible without re-rendering
+        container.style.height = 'auto';
+        container.style.overflow = 'visible';
+        return true;
+      }
+    }
+
     // Keep the real container hidden during detection
     container.style.height = '0';
     container.style.overflow = 'hidden';
@@ -629,9 +789,11 @@ async function detectStripeWithExistingContainer(price, { backgroundColor }, con
  * @returns {Promise<boolean>} Whether messaging is visible
  */
 async function updateStripeMessaging(price, { backgroundColor }, container, alignment = 'left') {
+  debugLog('BNPL', 'Updating Stripe messaging for price $' + price + ', alignment: ' + alignment);
+
   const elementId = PAYMENT_CONFIG.SUPPORTED_PROCESSORS.stripe.elementId;
   const element = container.querySelector(`#${elementId}`);
-  
+
   if (!element || typeof Stripe !== 'function') {
     return false;
   }
@@ -689,8 +851,10 @@ async function updateStripeMessaging(price, { backgroundColor }, container, alig
       container.style.overflow = 'hidden';
       return false;
     }
-    
-    // Keep container visible
+
+    // Make container visible
+    container.style.height = 'auto';
+    container.style.overflow = 'visible';
     return true;
   } catch (error) {
     console.warn('[BNPL] Stripe messaging update error:', error);
@@ -709,15 +873,17 @@ async function updateStripeMessaging(price, { backgroundColor }, container, alig
  * @returns {Promise<boolean>} Whether messaging is visible
  */
 async function showPaypalMessaging(
-  price, 
-  { backgroundColor }, 
-  container, 
-  isAlreadyVisible = false, 
-  alignment = 'left', 
+  price,
+  { backgroundColor },
+  container,
+  isAlreadyVisible = false,
+  alignment = 'left',
   pageType = 'product-details'
 ) {
+  debugLog('BNPL', 'Rendering PayPal messaging for price $' + price + ', alignment: ' + alignment + ', pageType: ' + pageType);
+
   const elementId = PAYMENT_CONFIG.SUPPORTED_PROCESSORS.paypal.elementId;
-  
+
   if (!container || typeof PayPalSDK === 'undefined') {
     return false;
   }

--- a/source/layout.html
+++ b/source/layout.html
@@ -499,7 +499,18 @@
     <script src="{{ theme | theme_js_url }}"></script>
     {% if page.full_url contains '/product/' %}
       <script>
-        Product.find('{{ product.permalink }}', processProduct)
+        // Initialize product data: fetch fresh on back/forward navigation (cache timing fix),
+        // use window.bigcartel.product on normal loads, or fetch as fallback
+        var navEntry = performance.getEntriesByType('navigation')[0];
+        var isBackForward = navEntry && navEntry.type === 'back_forward';
+
+        if (isBackForward) {
+          Product.find('{{ product.permalink }}', processProduct);
+        } else if (window.bigcartel?.product) {
+          processProduct(window.bigcartel.product);
+        } else {
+          Product.find('{{ product.permalink }}', processProduct);
+        }
       </script>
     {% endif %}
   </body>

--- a/source/product.html
+++ b/source/product.html
@@ -54,7 +54,7 @@
   </div>
   <div class="product-details">
     {% if product.status == 'active' %}
-      <form method="post" class="product-form {% if theme.show_sold_out_product_options %}show-sold-out{% else %}hide-sold-out{% endif %}" action="/cart" accept-charset="utf8">
+      <form id="add-to-cart-form" method="post" class="product-form {% if theme.show_sold_out_product_options %}show-sold-out{% else %}hide-sold-out{% endif %}" action="/cart" accept-charset="utf8">
         <input type="hidden" name="utf8" value='✓'>
         {% if product.has_default_option %}
           {{ product.option | hidden_option_input }}
@@ -86,7 +86,7 @@
             </div>
           {% endif %}
         {% endif %}
-        <button class="button add-to-cart-button" name="submit" type="submit" data-add-title="{{ t['products.add_to_cart'] }}" data-sold-title="{{ t['products.sold_out'] }}">{{ t['products.add_to_cart'] }}</button>
+        <button id="add-to-cart-button" class="button add-to-cart-button" type="submit" data-add-title="{{ t['products.add_to_cart'] }}" data-sold-title="{{ t['products.sold_out'] }}">{{ t['products.add_to_cart'] }}</button>
         {{ store | instant_checkout_button: 'dark', '44px' }}
         <div class="inventory-status-message" data-inventory-message></div>
         {% if product.has_option_groups %}

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Luna",
-  "version": "2.21.3",
+  "version": "2.21.4",
   "images": [
     {
       "variable": "welcome_image",


### PR DESCRIPTION
- chore(version): bump version to 2.21.4

- feat(html): add standardized IDs to form elements for improved testability and analytics
  - Added `id="contact_button"` to contact form submit button
  - Added `id="add-to-cart-button"` to add-to-cart button
  - Added `id="add-to-cart-form"` to product form
  - Removed redundant `name="submit"` attributes from buttons

- feat(bnpl): add debug logging infrastructure
  - Added global theme debug mode using sessionStorage (enable with `sessionStorage.setItem('themeDebug', 'true')`)
  - Implemented `debugLog()` utility function with category-based logging
  - Added debug logging throughout BNPL messaging system

- perf(bnpl): improve performance by parallelizing SDK rendering
  - Changed PayPal and Stripe SDK rendering from sequential to parallel execution using `Promise.all()`
  - Reduces total wait time by approximately 2 seconds (each SDK has 2s timeout)

- fix(bnpl): prevent layout shift on browser back/forward navigation
  - Detect back/forward navigation using Performance Navigation Timing API
  - Store parent container height in sessionStorage with page-specific keys
  - Pre-reserve space using cached height on back/forward navigation before SDK re-renders
  - Added 500ms delay after render to capture final stable height after SDK iframe layout completes
  - Keep container in layout flow when reserved height is available (prevents collapse during SDK re-render)

- fix(bnpl): improve re-render detection logic
  - Added exception to skip re-render caching on back/forward navigation (browser restores DOM but not SDK iframe content)
  - Added visibility checks to prevent unnecessary re-renders when price unchanged and messaging already visible
  - Enhanced debouncing with debug logging for better tracking

- fix(bnpl): optimize Stripe messaging detection
  - Check for existing Stripe iframe content before running detection (prevents unnecessary re-rendering on back/forward)
  - Skip temp container detection if Stripe content already rendered and meets minimum height threshold
  - Properly show container when skipping detection

- fix(bnpl): improve Stripe container visibility handling
  - Explicitly set `height: auto` and `overflow: visible` after successful Stripe render
  - Ensures container properly displays after updates

- fix(product): handle browser back/forward cache restoration for product option dropdowns
  - Added adaptive polling system (500ms max, 50ms intervals) to detect restored dropdown selections
  - Only polls on back/forward navigation (not on normal page loads)
  - Processes restored selections to enable add-to-cart button when all options selected
  - Added safety checks to abort polling if dropdowns removed from DOM
  - Uses Performance Navigation Timing API to detect navigation type

- fix(product): improve product data initialization timing
  - Detect back/forward navigation using Performance Navigation Timing API
  - Fetch fresh product data on back/forward navigation (fixes cache timing issues)
  - Use cached `window.bigcartel.product` on normal loads for better performance
  - Fallback to fetching if cached data unavailable

- fix(product): prevent duplicate event handlers
  - Changed product option event bindings to use namespaced events (`.productOptions`)
  - Use `.off()` before `.on()` to prevent duplicate handlers on re-initialization
  - Applies to dropdown change handlers and reset button click handlers

- refactor(product): move inventory message update to conditional execution
  - Only call `updateInventoryMessage()` if function exists
  - Prevents errors if function not defined in theme

- chore(code-quality): improve code formatting and consistency
  - Removed trailing whitespace
  - Standardized indentation
  - Updated error logging from `console.info` to `console.error` for invalid prices