### PR TITLE
Luna v2.22.0

### DIFF
--- a/source/cart.html
+++ b/source/cart.html
@@ -36,7 +36,19 @@
                   </div>
                 {% endunless %}
 
-                <div class="cart-item-details-unit-price">{{ item.unit_price | money: theme.money_format }}</div>
+                <div class="cart-item-details-unit-price">
+                  {% assign show_unit_strikethrough = false %}
+                  {% if theme.show_strikethrough_pricing and item.original_unit_price > item.unit_price %}
+                    {% assign show_unit_strikethrough = true %}
+                  {% endif %}
+
+                  {% if show_unit_strikethrough %}
+                    <s class="price-compare">{{ item.original_unit_price | money: theme.money_format }}</s>
+                    <span class="price-sale">{{ item.unit_price | money: theme.money_format }}</span>
+                  {% else %}
+                    {{ item.unit_price | money: theme.money_format }}
+                  {% endif %}
+                </div>
 
                 <button class="remove-item-button cart-item-remove-text minimal-button" type="button" aria-label="{{ t['cart.remove'] }}: {{ item.product.name | escape }}">{{ t['cart.remove'] }}</button>
               </div>

--- a/source/home.html
+++ b/source/home.html
@@ -123,7 +123,32 @@
                     {% endif %}
 
                     {% unless hide_price %}
-                      {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                      {% assign show_strikethrough = false %}
+                      {% assign strikethrough_regular = nil %}
+                      {% assign strikethrough_sale = nil %}
+
+                      {% if theme.show_strikethrough_pricing %}
+                        {% if product.variable_pricing == false and product.original_price > product.default_price %}
+                          {% assign show_strikethrough = true %}
+                          {% assign strikethrough_regular = product.original_price %}
+                          {% assign strikethrough_sale = product.default_price %}
+                        {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "min_only" and product.min_original_price > product.min_price %}
+                          {% assign show_strikethrough = true %}
+                          {% assign strikethrough_regular = product.min_original_price %}
+                          {% assign strikethrough_sale = product.min_price %}
+                        {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "max_only" and product.max_original_price > product.max_price %}
+                          {% assign show_strikethrough = true %}
+                          {% assign strikethrough_regular = product.max_original_price %}
+                          {% assign strikethrough_sale = product.max_price %}
+                        {% endif %}
+                      {% endif %}
+
+                      {% if show_strikethrough %}
+                        <s class="price-compare">{{ strikethrough_regular | money: theme.money_format }}</s>
+                        <span class="price-sale">{{ strikethrough_sale | money: theme.money_format }}</span>
+                      {% else %}
+                        {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                      {% endif %}
 
                       {% if product.price_suffix != blank %}
                         {% assign variable_price_shown = true %}

--- a/source/home.html
+++ b/source/home.html
@@ -143,7 +143,7 @@
                   {% unless hide_price %}
                     {% if product.options.size > 1 and theme.show_product_variant_count_in_grid %}
                       <div class="product-list-thumb-options-description">
-                        {{ product.options.size }} {{ t['products.variants'] }}
+                        {{ product.options.size }} {{ t['products.variants'] | downcase }}
                       </div>
                     {% endif %}
                   {% endunless %}

--- a/source/javascripts/cart.js
+++ b/source/javascripts/cart.js
@@ -123,11 +123,14 @@ var processUpdate = function(input, item_id, new_val, cart) {
   if (new_val > 0) {
     for (itemIndex = 0; itemIndex < cart.items.length; itemIndex++) {
       if (cart.items[itemIndex].id == item_id) {
-        item_price = cart.items[itemIndex].price;
-        formatted_item_price = strip_tags(formatMoney(item_price, true, true));
-        item_price_element = $('.cart-item[data-item-id="'+item_id+'"]').find('.cart-item-details-price__update');
+        var item = cart.items[itemIndex];
+        var item_price = item.price;
+        var item_price_element = $('.cart-item[data-item-id="'+item_id+'"]').find('.cart-item-details-price__update');
+
+        // Line total only shows sale price (no strikethrough - strikethrough is on unit price only)
+        var formattedPrice = strip_tags(formatMoney(item_price, true, true));
         item_price_element.fadeOut(100, function() {
-          item_price_element.html(formatted_item_price);
+          item_price_element.html(formattedPrice);
           item_price_element.fadeIn(500);
         });
       }

--- a/source/javascripts/product-option-groups.js
+++ b/source/javascripts/product-option-groups.js
@@ -305,7 +305,7 @@ function processAvailableDropdownOptions(product, changed_dropdown) {
     if (product_option) {
       if (!product_option.sold_out && product_option.id > 0) {
         $('#option').val(product_option.id);
-        enableAddButton(product_option.price);
+        enableAddButton(product_option.price, product_option.original_price);
         if (num_option_groups > 1) {
           $('.reset-selection-button').fadeIn('fast');
         }

--- a/source/javascripts/product.js
+++ b/source/javascripts/product.js
@@ -101,6 +101,17 @@ function updateProductPrice(updated_price, original_price) {
   var priceContainer = $('.product-price-value');
   if (!priceContainer.length) return;
 
+  if (!updated_price) {
+    if (priceContainer.data('original-html') !== undefined) {
+      priceContainer.html(priceContainer.data('original-html'));
+    }
+    return;
+  }
+
+  if (priceContainer.data('original-html') === undefined) {
+    priceContainer.data('original-html', priceContainer.html());
+  }
+
   // Convert to numbers for proper comparison (data attributes are strings)
   var updatedNum = parseFloat(updated_price) || 0;
   var originalNum = parseFloat(original_price) || 0;

--- a/source/javascripts/product.js
+++ b/source/javascripts/product.js
@@ -31,8 +31,10 @@ if (themeOptions.productImageZoom === true) {
 
 
 $('.product-option-select').on('change',function() {
-  var option_price = $(this).find("option:selected").attr("data-price");
-  enableAddButton(option_price);
+  var selectedOption = $(this).find("option:selected");
+  var option_price = selectedOption.attr("data-price");
+  var original_price = selectedOption.attr("data-original-price");
+  enableAddButton(option_price, original_price);
 });
 
 function updateInventoryMessage(optionId = null) {
@@ -95,18 +97,54 @@ function updateInventoryMessage(optionId = null) {
   }
 }
 
-function enableAddButton(updated_price) {
+function updateProductPrice(updated_price, original_price) {
+  var priceContainer = $('.product-price-value');
+  if (!priceContainer.length) return;
+
+  // Convert to numbers for proper comparison (data attributes are strings)
+  var updatedNum = parseFloat(updated_price) || 0;
+  var originalNum = parseFloat(original_price) || 0;
+
+  var showStrikethrough = originalNum > updatedNum &&
+                          themeOptions.showStrikethroughPricing;
+
+  var priceHtml;
+  if (showStrikethrough) {
+    var regularFormatted = formatMoney(original_price, true, true);
+    var saleFormatted = formatMoney(updated_price, true, true);
+    priceHtml = '<s class="price-compare">' + regularFormatted + '</s> <span class="price-sale">' + saleFormatted + '</span>';
+  } else {
+    priceHtml = formatMoney(updated_price, true, true);
+  }
+
+  priceContainer.html(priceHtml);
+}
+
+function enableAddButton(updated_price, original_price) {
   var addButton = $('.add-to-cart-button');
   var addButtonTitle = addButton.attr('data-add-title');
   addButton.attr("disabled",false);
+
+  // On mobile, the price display is far from the button due to the product image between them.
+  // Show the price in the button so users see price changes when selecting options.
   if (updated_price) {
-    priceTitle = ' - ' + formatMoney(updated_price, true, true);
+    var updatedNum = parseFloat(updated_price) || 0;
+    var originalNum = parseFloat(original_price) || 0;
+    var showStrikethrough = originalNum > updatedNum && themeOptions.showStrikethroughPricing;
+
+    var priceHtml;
+    if (showStrikethrough) {
+      priceHtml = '<s class="price-compare">' + formatMoney(original_price, true, true) + '</s> <span class="price-sale">' + formatMoney(updated_price, true, true) + '</span>';
+    } else {
+      priceHtml = formatMoney(updated_price, true, true);
+    }
+    addButton.html('<span class="button-add-price">' + priceHtml + '</span><span class="button-add-text">' + addButtonTitle + '</span>');
+    updateProductPrice(updated_price, original_price);
+  } else {
+    addButton.html(addButtonTitle);
   }
-  else {
-    priceTitle = '';
-  }
-  addButton.html(addButtonTitle + priceTitle);
-  addButton.attr('aria-label',addButton.text());
+
+  addButton.attr('aria-label', addButtonTitle);
   updateInventoryMessage($('#option').val());
   showBnplMessaging(updated_price, { alignment: 'center', displayMode: 'flex', pageType: 'product' });
 }
@@ -165,8 +203,16 @@ document.addEventListener('DOMContentLoaded', () => {
   const isProductPage = document.body.getAttribute('data-bc-page-type') === 'product';
   if (isProductPage) {
     updateInventoryMessage();
-    
-    const price = window.bigcartel?.product?.default_price || null;    
+
+    const product = window.bigcartel?.product;
+    const price = product?.default_price || null;
+
+    // Initialize button price for default option products
+    if (product?.options?.length === 1) {
+      const option = product.options[0];
+      enableAddButton(option.price, option.original_price);
+    }
+
     showBnplMessaging(price, { alignment: 'center', displayMode: 'flex', pageType: 'product' });
   }
 });

--- a/source/layout.html
+++ b/source/layout.html
@@ -195,8 +195,33 @@
                             {% endif %}
 
                             {% unless hide_price %}
-                              {{ related_product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
-                            
+                              {% assign show_strikethrough = false %}
+                              {% assign strikethrough_regular = nil %}
+                              {% assign strikethrough_sale = nil %}
+
+                              {% if theme.show_strikethrough_pricing %}
+                                {% if related_product.variable_pricing == false and related_product.original_price > related_product.default_price %}
+                                  {% assign show_strikethrough = true %}
+                                  {% assign strikethrough_regular = related_product.original_price %}
+                                  {% assign strikethrough_sale = related_product.default_price %}
+                                {% elsif related_product.variable_pricing and theme.product_variable_pricing_display_format == "min_only" and related_product.min_original_price > related_product.min_price %}
+                                  {% assign show_strikethrough = true %}
+                                  {% assign strikethrough_regular = related_product.min_original_price %}
+                                  {% assign strikethrough_sale = related_product.min_price %}
+                                {% elsif related_product.variable_pricing and theme.product_variable_pricing_display_format == "max_only" and related_product.max_original_price > related_product.max_price %}
+                                  {% assign show_strikethrough = true %}
+                                  {% assign strikethrough_regular = related_product.max_original_price %}
+                                  {% assign strikethrough_sale = related_product.max_price %}
+                                {% endif %}
+                              {% endif %}
+
+                              {% if show_strikethrough %}
+                                <s class="price-compare">{{ strikethrough_regular | money: theme.money_format }}</s>
+                                <span class="price-sale">{{ strikethrough_sale | money: theme.money_format }}</span>
+                              {% else %}
+                                {{ related_product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                              {% endif %}
+
                               {% if related_product.price_suffix != blank %}
                                 {% assign variable_price_shown = true %}
                                 {% if theme.product_variable_pricing_display_format == "min_only" or theme.product_variable_pricing_display_format == "max_only" %}
@@ -452,6 +477,8 @@
         homeFeaturedVideoUrl: "{{ theme.home_featured_video_url }}",
         homeFeaturedVideoSize: "{{ theme.home_featured_video_size }}",
         homeFeaturedVideoBorder: "{{ theme.home_featured_video_border }}",
+        showStrikethroughPricing: {{ theme.show_strikethrough_pricing }},
+        showSaleLabelInProductOptions: {{ theme.show_sale_label_in_product_options }},
       };
       const themeTranslations = {
         cart: {

--- a/source/layout.html
+++ b/source/layout.html
@@ -242,6 +242,9 @@
     {% if pages.required_pages.size > 0 %}
       {% assign show_pages_section_in_footer = true %}
     {% endif %}
+    {% if store.website != blank %}
+      {% assign show_pages_section_in_footer = true %}
+    {% endif %}
     <footer data-bc-hook="footer">
       <div class="wrapper">
         {% if theme.footer_text != blank and theme.footer_text_position == "start" %}

--- a/source/layout.html
+++ b/source/layout.html
@@ -215,7 +215,7 @@
                           {% unless hide_price %}
                             {% if related_product.options.size > 1 and theme.show_product_variant_count_in_grid %}
                               <div class="product-list-thumb-options-description">
-                                {{ related_product.options.size }} {{ t['products.variants'] }}
+                                {{ related_product.options.size }} {{ t['products.variants'] | downcase }}
                               </div>
                             {% endif %}
                           {% endunless %}

--- a/source/product.html
+++ b/source/product.html
@@ -108,11 +108,7 @@
       </div>
     {% endif %}
 
-    {% if product.description != blank %}
-      <div class="product-description">
-        {{ product.description | paragraphs }}
-      </div>
-    {% endif %}
+    <div class="product-description" data-bc-hook="product-description">{%- if product.description != blank %}{{ product.description | paragraphs }}{% endif -%}</div>
 
     {% if product.status == 'active' %}
       {% if theme.show_inventory_bars %}

--- a/source/product.html
+++ b/source/product.html
@@ -217,6 +217,7 @@
                 <img
                   alt=""
                   class="lazyload"
+                  loading="lazy"
                   src="{{ image | product_image_url | constrain: 150 }}"
                   data-srcset="
                     {{ image | product_image_url | constrain: 250 }} 250w,

--- a/source/product.html
+++ b/source/product.html
@@ -33,9 +33,25 @@
         {% assign hide_price = true %}
       {% endif %}
 
-      {% unless hide_price %}
-        {{ product | product_price: theme.money_format }}
-      {% endunless %}
+      <span class="product-price-value">
+        {% unless hide_price %}
+          {% capture product_pricing %}
+            {% assign show_strikethrough = false %}
+            {% if theme.show_strikethrough_pricing and product.variable_pricing == false and product.original_price > product.default_price %}
+              {% assign show_strikethrough = true %}
+            {% endif %}
+
+            {% if show_strikethrough %}
+              <s class="price-compare">{{ product.original_price | money: theme.money_format }}</s>
+              <span class="price-sale">{{ product.default_price | money: theme.money_format }}</span>
+            {% else %}
+              {{ product | product_price: theme.money_format }}
+            {% endif %}
+          {% endcapture %}
+
+          {{ product_pricing }}
+        {% endunless %}
+      </span>
 
       {% if product.price_suffix != blank %}
         {% assign variable_price_shown = true %}
@@ -64,10 +80,29 @@
               <input id="option" name="cart[add][id]" type="hidden" value="0">
               {% for option_group in product.option_groups %}
                 <div class="select">
-                  <select data-unavailable-text="(Unavailable)" data-sold-text="({{ t['products.sold_out'] }})" data-group-id="{{ option_group.id }}" data-group-name="{{ option_group.name | escape }}" class="product_option_group" name="option_group[{{ option_group.id }}]" aria-label="Select {{ option_group.name | escape }}" required>
+                  <select data-unavailable-text="(Unavailable)" data-sold-text="({{ t['products.sold_out'] }})" data-sale-text="({{ t['products.on_sale'] | downcase }})" data-group-id="{{ option_group.id }}" data-group-name="{{ option_group.name | escape }}" class="product_option_group" name="option_group[{{ option_group.id }}]" aria-label="Select {{ option_group.name | escape }}" required>
                     <option value="" disabled="disabled" selected>{{ option_group.name }}</option>
                     {% for value in option_group.values %}
-                      <option value="{{ value.id }}" data-name="{{ value.name | escape }}">{{ value.name }}</option>
+                      {% comment %}
+                        For single option groups, we can show status labels since each value maps to one product option.
+                        For multiple option groups, we can't know status until all selections are made.
+                      {% endcomment %}
+                      {% assign option_status_label = '' %}
+                      {% if product.option_groups.size == 1 %}
+                        {% for option in product.options %}
+                          {% for ogv in option.option_group_values %}
+                            {% if ogv.id == value.id %}
+                              {% if option.sold_out %}
+                                {% assign option_status_label = t['products.sold_out'] | downcase %}
+                              {% elsif option.original_price > option.price and theme.show_sale_label_in_product_options %}
+                                {% assign option_status_label = t['products.on_sale'] | downcase %}
+                              {% endif %}
+                              {% break %}
+                            {% endif %}
+                          {% endfor %}
+                        {% endfor %}
+                      {% endif %}
+                      <option value="{{ value.id }}" data-name="{{ value.name | escape }}">{{ value.name }}{% if option_status_label != blank %} ({{ option_status_label }}){% endif %}</option>
                     {% endfor %}
                   </select>
                   <svg viewBox="0 0 15 7.6" enable-background="new 0 0 15 7.6"><path d="M15 1.1l-7.5 6.5-7.5-6.3 1-1.2 6.5 5.5 6.5-5.6z"/></svg>
@@ -79,7 +114,7 @@
               <select class="product-option-select" id="option" name="cart[add][id]" aria-label="{{ t['products.select_variant'] }}" required>
                 <option value="" disabled="disabled" selected>{{ t['products.select_variant'] }}</option>
                 {% for option in product.options %}
-                  <option value="{{ option.id }}" data-price="{{ option.price }}"{% if option.sold_out %} disabled="disabled" disabled-type="sold-out"{% endif %}>{{ option.name }} {% if option.sold_out %} ({{ t['products.sold_out'] }}){% endif %}</option>
+                  <option value="{{ option.id }}" data-price="{{ option.price }}" data-original-price="{{ option.original_price }}"{% if option.sold_out %} disabled="disabled" disabled-type="sold-out"{% endif %}>{{ option.name }} {% if option.sold_out %} ({{ t['products.sold_out'] | downcase }}){% elsif option.original_price > option.price and theme.show_sale_label_in_product_options %} ({{ t['products.on_sale'] | downcase }}){% endif %}</option>
                 {% endfor %}
               </select>
               <svg viewBox="0 0 15 7.6" enable-background="new 0 0 15 7.6"><path d="M15 1.1l-7.5 6.5-7.5-6.3 1-1.2 6.5 5.5 6.5-5.6z"/></svg>

--- a/source/products.html
+++ b/source/products.html
@@ -90,7 +90,32 @@
                   {% endif %}
 
                   {% unless hide_price %}
-                    {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                    {% assign show_strikethrough = false %}
+                    {% assign strikethrough_regular = nil %}
+                    {% assign strikethrough_sale = nil %}
+
+                    {% if theme.show_strikethrough_pricing %}
+                      {% if product.variable_pricing == false and product.original_price > product.default_price %}
+                        {% assign show_strikethrough = true %}
+                        {% assign strikethrough_regular = product.original_price %}
+                        {% assign strikethrough_sale = product.default_price %}
+                      {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "min_only" and product.min_original_price > product.min_price %}
+                        {% assign show_strikethrough = true %}
+                        {% assign strikethrough_regular = product.min_original_price %}
+                        {% assign strikethrough_sale = product.min_price %}
+                      {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "max_only" and product.max_original_price > product.max_price %}
+                        {% assign show_strikethrough = true %}
+                        {% assign strikethrough_regular = product.max_original_price %}
+                        {% assign strikethrough_sale = product.max_price %}
+                      {% endif %}
+                    {% endif %}
+
+                    {% if show_strikethrough %}
+                      <s class="price-compare">{{ strikethrough_regular | money: theme.money_format }}</s>
+                      <span class="price-sale">{{ strikethrough_sale | money: theme.money_format }}</span>
+                    {% else %}
+                      {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                    {% endif %}
 
                     {% if product.price_suffix != blank %}
                       {% assign variable_price_shown = true %}

--- a/source/products.html
+++ b/source/products.html
@@ -110,7 +110,7 @@
                 {% unless hide_price %}
                   {% if product.options.size > 1 and theme.show_product_variant_count_in_grid %}
                     <div class="product-list-thumb-options-description">
-                      {{ product.options.size }} {{ t['products.variants'] }}
+                      {{ product.options.size }} {{ t['products.variants'] | downcase }}
                     </div>
                   {% endif %}
                 {% endunless %}

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Luna",
-  "version": "2.21.5",
+  "version": "2.22.0",
   "images": [
     {
       "variable": "welcome_image",

--- a/source/settings.json
+++ b/source/settings.json
@@ -626,7 +626,8 @@
       "options": [
         ["Default (Sentence case)", "initial"],
         ["Uppercase", "uppercase"],
-        ["Lowercase", "lowercase"]
+        ["Lowercase", "lowercase"],
+        ["Titlecase", "capitalize"]
       ],
       "default": "initial",
       "description": "Controls the text case styling in your main navigation"
@@ -639,7 +640,8 @@
       "options": [
         ["Default (Sentence case)", "initial"],
         ["Uppercase", "uppercase"],
-        ["Lowercase", "lowercase"]
+        ["Lowercase", "lowercase"],
+        ["Titlecase", "capitalize"]
       ],
       "default": "initial",
       "description": "Controls the text case styling in the footer, excluding custom footer text"

--- a/source/settings.json
+++ b/source/settings.json
@@ -1028,6 +1028,25 @@
       "description": "For products with multiple variants, show the variant count in product grids."
     },
     {
+      "variable": "show_strikethrough_pricing",
+      "label": "Show strikethrough pricing",
+      "section": "product_page",
+      "type": "boolean",
+      "default": true,
+      "description": "Show the original price crossed out next to the sale price",
+      "requires": [
+        "feature:theme_strikethrough_pricing eq visible"
+      ]
+    },
+    {
+      "variable": "show_sale_label_in_product_options",
+      "label": "Show sale label in variant dropdowns",
+      "section": "product_page",
+      "type": "boolean",
+      "default": true,
+      "description": "Adds a sale indicator next to discounted variants in the dropdown"
+    },
+    {
       "variable": "product_page_layout",
       "label": "Product page layout",
       "section": "product_page",

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -91,6 +91,9 @@
     font-size: calc(#{$luna-font-base-px} * var(--product-description-scale, 1))
     margin-top: 32px
 
+    &:empty
+      display: none
+
     a
       color: var(--link-text-color)
       text-decoration: underline

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -73,6 +73,21 @@
     display: block
     width: 100%
 
+    .button-add-price
+      display: none
+
+    @media screen and (max-width: $break-small)
+      display: flex
+      flex-direction: column
+      align-items: center
+      height: auto
+      padding: 12px 20px
+
+      .button-add-price
+        display: block
+        margin-bottom: 4px
+        font-size: 0.875rem
+
   .reset-selection-button-container
     text-align: center
     width: 100%

--- a/source/stylesheets/products.sass
+++ b/source/stylesheets/products.sass
@@ -241,3 +241,9 @@ a.product-list-link
   @media screen and (max-width: $break-small)
     .empty-products
       padding-bottom: $luna-base * 8
+
+// Strikethrough pricing styles
+.price-compare
+  text-decoration: line-through
+  opacity: 0.6
+  margin-right: 0.3em


### PR DESCRIPTION
## Summary

### Features
- **Strikethrough pricing** — Display original prices with strikethrough when items are on sale
- **Titlecase nav text transformation** — New option to apply titlecase formatting to navigation text

### Fixes
- **Product description container always in DOM** — The product description container is now always rendered (with a `data-bc-hook`) so it can be targeted by JS, and hidden via CSS `:empty` when there's no description
- **"Back to site" footer link** — The "back to site" link now correctly displays in the footer when available

### Chores
- Lowercase label for options text in product grid
- Version bump to 2.22.0